### PR TITLE
Separate licenseType field (#39/#55)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <!-- VLO-mapping project version to obtain default mappings from at build time -->
-        <vlo.mapping.version>1.0.0</vlo.mapping.version>
+        <vlo.mapping.version>1.1-SNAPSHOT</vlo.mapping.version>
         
         <!-- Common runtime dependency versions -->
         <solr.version>4.10.4</solr.version>

--- a/vlo-commons/src/main/java/eu/clarin/cmdi/vlo/FacetConstants.java
+++ b/vlo-commons/src/main/java/eu/clarin/cmdi/vlo/FacetConstants.java
@@ -85,6 +85,7 @@ public class FacetConstants {
             FIELD_KEYWORDS,
             FIELD_LANGUAGE_CODE,
             FIELD_LICENSE,
+            FIELD_LICENSE_TYPE,
             FIELD_MODALITY,
             FIELD_NAME,
             FIELD_NATIONAL_PROJECT,

--- a/vlo-commons/src/main/java/eu/clarin/cmdi/vlo/FacetConstants.java
+++ b/vlo-commons/src/main/java/eu/clarin/cmdi/vlo/FacetConstants.java
@@ -30,6 +30,7 @@ public class FacetConstants {
     public static final String FIELD_RESOURCE_CLASS = "resourceClass";
     public static final String FIELD_SUBJECT = "subject";
     public static final String FIELD_TEMPORAL_COVERAGE = "temporalCoverage";
+    public static final String FIELD_LICENSE_TYPE = "licenseType";
 
     /**
      * Solr pseudo-field that reveals the ranking score

--- a/vlo-commons/src/main/java/eu/clarin/cmdi/vlo/FacetConstants.java
+++ b/vlo-commons/src/main/java/eu/clarin/cmdi/vlo/FacetConstants.java
@@ -1,5 +1,6 @@
 package eu.clarin.cmdi.vlo;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 
@@ -155,5 +156,11 @@ public class FacetConstants {
      * @see #FIELD_AVAILABILITY
      */
     public static final String AVAILABILITY_LEVEL_RES = "RES";
+
+    public static final ImmutableList<String> LICENSE_TYPE_VALUES = ImmutableList.of(
+            FacetConstants.AVAILABILITY_LEVEL_PUB,
+            FacetConstants.AVAILABILITY_LEVEL_ACA,
+            FacetConstants.AVAILABILITY_LEVEL_RES
+    );
 
 }

--- a/vlo-commons/src/main/java/eu/clarin/cmdi/vlo/config/VloConfig.java
+++ b/vlo-commons/src/main/java/eu/clarin/cmdi/vlo/config/VloConfig.java
@@ -73,6 +73,8 @@ public class VloConfig {
     private String licenseAvailabilityMapUrl;
     
     private String licenseURIMapUrl;
+    
+    private String licenseTypeMapUrl;
 
     private String countryComponentUrl = "";
 
@@ -1068,6 +1070,13 @@ public class VloConfig {
 
     public void setLicenseURIMapUrl(String licenseURIMapUrl) {
         this.licenseURIMapUrl = licenseURIMapUrl;
+    }
+    public String getLicenseTypeMapUrl() {
+        return licenseTypeMapUrl;
+    }
+
+    public void setLicenseTypeMapUrl(String licenseURIMapUrl) {
+        this.licenseTypeMapUrl = licenseURIMapUrl;
     }
 
     /**

--- a/vlo-commons/src/main/resources/VloConfig.xml
+++ b/vlo-commons/src/main/resources/VloConfig.xml
@@ -54,7 +54,9 @@
     <licenseAvailabilityMapUrl>${vloconfig.mappingFilesLocation}LicenseAvailabilityMap.xml</licenseAvailabilityMapUrl> <!-- bundled resource: /uniform-maps/LicenseAvailabilityMap.xml -->
     
     <licenseURIMapUrl>${vloconfig.mappingFilesLocation}LicenseURIMap.xml</licenseURIMapUrl> <!-- bundled resource: /uniform-maps/LicenseURIMap.xml -->
-    
+
+    <licenseTypeMapUrl>${vloconfig.mappingFilesLocation}LicenseTypeMap.xml</licenseTypeMapUrl> <!-- bundled resource: /uniform-maps/LicenseAvailabilityMap.xml -->
+            
     <!-- Fields shown as facets on the search page -->
     <facetFields>        
         <facetField>languageCode</facetField>

--- a/vlo-commons/src/main/resources/VloConfig.xml
+++ b/vlo-commons/src/main/resources/VloConfig.xml
@@ -69,7 +69,6 @@
         <facetField>organisation</facetField>
         <facetField>nationalProject</facetField>
         <facetField>dataProvider</facetField>
-        <facetField>licenseType</facetField>
     </facetFields>
         
     <simpleSearchFacetFields>
@@ -111,6 +110,7 @@
         <ignoredField>score</ignoredField>
         <ignoredField>license</ignoredField>
         <ignoredField>availability</ignoredField>
+        <ignoredField>licenseType</ignoredField>
         <ignoredField>accessInfo</ignoredField>
     </ignoredFields>
     

--- a/vlo-commons/src/main/resources/VloConfig.xml
+++ b/vlo-commons/src/main/resources/VloConfig.xml
@@ -69,6 +69,7 @@
         <facetField>organisation</facetField>
         <facetField>nationalProject</facetField>
         <facetField>dataProvider</facetField>
+        <facetField>licenseType</facetField>
     </facetFields>
         
     <simpleSearchFacetFields>

--- a/vlo-commons/src/test/java/eu/clarin/cmdi/vlo/config/DefaultVloConfigFactoryTest.java
+++ b/vlo-commons/src/test/java/eu/clarin/cmdi/vlo/config/DefaultVloConfigFactoryTest.java
@@ -905,7 +905,7 @@ public class DefaultVloConfigFactoryTest {
     @Test
     public void testGetIgnoredFields() {
         Set<String> result = config.getIgnoredFields();
-        assertEquals(5, result.size());
+        assertEquals(6, result.size());
     }
 
     @Test

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/AvailabilityPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/AvailabilityPostProcessor.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class AvailabilityPostProcessor extends PostProcessorsWithVocabularyMap {
 
     @Override
-    public List<String> process(final String value) {
+    public List<String> process(final String value, CMDIData cmdiData) {
         String normalizedVal = normalize(value);
         //Availability variants can be normalized with multiple values, in vocabulary they are separated with ;
         return normalizedVal != null ? Arrays.asList(normalizedVal.split(";")) : new ArrayList<>();

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/AvailabilityPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/AvailabilityPostProcessor.java
@@ -21,4 +21,9 @@ public class AvailabilityPostProcessor extends PostProcessorsWithVocabularyMap {
     public String getNormalizationMapURL() {
         return MetadataImporter.config.getLicenseAvailabilityMapUrl();
     }
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
+    }
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIComponentProfileNamePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIComponentProfileNamePostProcessor.java
@@ -74,6 +74,11 @@ public class CMDIComponentProfileNamePostProcessor implements PostProcessor {
         return resultList;
     }
 
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
+    }
+
     private void setup() {
         ap = new AutoPilot();
         try {

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIComponentProfileNamePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIComponentProfileNamePostProcessor.java
@@ -27,7 +27,7 @@ public class CMDIComponentProfileNamePostProcessor implements PostProcessor {
     private final HashMap<String, String> cache = new HashMap<String, String>();
 
     @Override
-    public List<String> process(String profileId) {
+    public List<String> process(String profileId, CMDIData cmdiData) {
         String result = _EMPTY_STRING;
         if(profileId != null){
             if(cache.containsKey(profileId)){

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIData.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIData.java
@@ -89,7 +89,7 @@ public class CMDIData {
             } //ignore double values don't add them
         }
     }
-    
+
     public Collection<Object> getDocField(String name) {
         if (doc == null) {
             return null;
@@ -150,10 +150,11 @@ public class CMDIData {
             searchResources.add(new Resource(resource, type, mimeType));
         } else if (LANDING_PAGE_TYPE.equals(type)) {
             // omit multiple LandingPages
-            if(landingPageResources.isEmpty())
+            if (landingPageResources.isEmpty()) {
                 landingPageResources.add(new Resource(resource, type, mimeType));
-            else
+            } else {
                 LOG.warn("Ignoring surplus landingpage: {}", resource);
+            }
         } else if (SEARCH_PAGE_TYPE.equals(type)) {
             searchPageResources.add(new Resource(resource, type, mimeType));
         } else {
@@ -170,8 +171,12 @@ public class CMDIData {
         return id;
     }
 
-    /*
-     * In case that Availability facet has more then one value use the most restrictive tag from PUB, ACA and RES 
+    /**
+     * In case that Availability facet has more then one value use the most
+     * restrictive tag from PUB, ACA and RES. TODO: Move this to post processor
+     *
+     * @param field field to reduce availability values in
+     * @param value value to insert (add or replace)
      */
     private void reduceAvailability(String field, String value) {
         Collection<Object> currentValues = doc.getFieldValues(field);

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIData.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIData.java
@@ -89,6 +89,14 @@ public class CMDIData {
             } //ignore double values don't add them
         }
     }
+    
+    public Collection<Object> getDocField(String name) {
+        if (doc == null) {
+            return null;
+        } else {
+            return doc.getFieldValues(name);
+        }
+    }
 
     public List<Resource> getDataResources() {
         return dataResources;

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIData.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIData.java
@@ -81,8 +81,8 @@ public class CMDIData {
             Collection<Object> fieldValues = doc.getFieldValues(name);
             if (fieldValues == null || !fieldValues.contains(value)) {
                 //if availability facet reduce tag to most restrictive
-                if (name.equals(FacetConstants.FIELD_AVAILABILITY)) {
-                    reduceAvailability(value);
+                if (name.equals(FacetConstants.FIELD_AVAILABILITY) || name.equals(FacetConstants.FIELD_LICENSE_TYPE)) {
+                    reduceAvailability(name, value);
                 } else {
                     doc.addField(name, value);
                 }
@@ -173,18 +173,18 @@ public class CMDIData {
     /*
      * In case that Availability facet has more then one value use the most restrictive tag from PUB, ACA and RES 
      */
-    private void reduceAvailability(String value) {
-        Collection<Object> currentValues = doc.getFieldValues(FacetConstants.FIELD_AVAILABILITY);
+    private void reduceAvailability(String field, String value) {
+        Collection<Object> currentValues = doc.getFieldValues(field);
 
         //the first value
         if (currentValues == null) {
-            doc.addField(FacetConstants.FIELD_AVAILABILITY, value);
+            doc.addField(field, value);
             return;
         }
 
         int lvlNew = availabilityToLvl(value);
         if (lvlNew == -1) { //other tags, add them, uniqueness has already being checked
-            doc.addField(FacetConstants.FIELD_AVAILABILITY, value);
+            doc.addField(field, value);
             return;
         }
 
@@ -199,8 +199,8 @@ public class CMDIData {
 
         //if new values is more restrictive replace the old with new
         if (lvlNew > lvlCur) {
-            SolrInputField fOld = doc.get(FacetConstants.FIELD_AVAILABILITY);
-            SolrInputField fNew = new SolrInputField(FacetConstants.FIELD_AVAILABILITY);
+            SolrInputField fOld = doc.get(field);
+            SolrInputField fNew = new SolrInputField(field);
 
             fNew.addValue(value, 1.0f); //new, more restrictive value
             for (Object val : fOld.getValues()) { //copy other tags
@@ -209,7 +209,7 @@ public class CMDIData {
                 }
             }
 
-            doc.replace(FacetConstants.FIELD_AVAILABILITY, fOld, fNew);
+            doc.replace(field, fOld, fNew);
         }
 
     }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIParserVTDXML.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIParserVTDXML.java
@@ -301,7 +301,7 @@ public class CMDIParserVTDXML implements CMDIDataProcessor {
             final String value = nav.toString(index);
             final String languageCode = extractLanguageCode(nav);
 
-            for(String postprocessedValue : postProcess(config.getName(), value)) {
+            for(String postprocessedValue : postProcess(config.getName(), value, cmdiData)) {
                 // ignore non-English language names for facet LANGUAGE_CODE
                 if (config.getName().equals(FacetConstants.FIELD_LANGUAGE_CODE) && !languageCode.equals("code:eng") && !languageCode.equals(DEFAULT_LANGUAGE)) {
                     continue;
@@ -343,7 +343,7 @@ public class CMDIParserVTDXML implements CMDIDataProcessor {
         for (String derivedFacet : config.getDerivedFacets()) {
             final List<Pair<String, String>> derivedValueLangPairList = new ArrayList<>();
             for (Pair<String, String> valueLangPair : finalValueLangPairList) {
-                for (String derivedValue : postProcess(derivedFacet, valueLangPair.getLeft())) {
+                for (String derivedValue : postProcess(derivedFacet, valueLangPair.getLeft(), null)) {
                     derivedValueLangPairList.add(new ImmutablePair<>(derivedValue, valueLangPair.getRight()));
                 }
             }
@@ -363,7 +363,7 @@ public class CMDIParserVTDXML implements CMDIDataProcessor {
             return DEFAULT_LANGUAGE;
         }
 
-        return postProcessors.get(FacetConstants.FIELD_LANGUAGE_CODE).process(languageCode).get(0);
+        return postProcessors.get(FacetConstants.FIELD_LANGUAGE_CODE).process(languageCode, null).get(0);
     }
 
     private void insertFacetValues(String name, List<Pair<String, String>> valueLangPairList, CMDIData cmdiData, boolean allowMultipleValues, boolean caseInsensitive) {
@@ -387,11 +387,11 @@ public class CMDIParserVTDXML implements CMDIDataProcessor {
      * @return value after applying matching PostProcessor or the original value
      * if no PostProcessor was registered for the facet
      */
-    private List<String> postProcess(String facetName, String extractedValue) {
+    private List<String> postProcess(String facetName, String extractedValue, CMDIData cmdiData) {
         List<String> resultList = new ArrayList<>();
         if (postProcessors.containsKey(facetName)) {
             PostProcessor processor = postProcessors.get(facetName);
-            resultList = processor.process(extractedValue);
+            resultList = processor.process(extractedValue, cmdiData);
         } else {
             resultList.add(extractedValue);
         }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIParserVTDXML.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIParserVTDXML.java
@@ -286,10 +286,10 @@ public class CMDIParserVTDXML implements CMDIDataProcessor {
                 if (postProcessors.get(fieldWithPostProcessor).doesProcessNoValue()) {
                     //get properties from facet concept definition
                     if (facetConceptMap == null) {
-                        FacetConceptMapping facetConceptMapping = VLOMarshaller.getFacetConceptMapping(MetadataImporter.config.getFacetConceptsFile());
+                        final FacetConceptMapping facetConceptMapping = VLOMarshaller.getFacetConceptMapping(config.getFacetConceptsFile());
                         facetConceptMap = facetConceptMapping.getFacetConceptMap();
                     }
-                    FacetConceptMapping.FacetConcept facetConcept = facetConceptMap.get(fieldWithPostProcessor);
+                    final FacetConceptMapping.FacetConcept facetConcept = facetConceptMap.get(fieldWithPostProcessor);
                     processNoMatch(fieldWithPostProcessor, facetConcept.isAllowMultipleValues(), facetConcept.isCaseInsensitive(), cmdiData);
                 }
             }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIParserVTDXML.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIParserVTDXML.java
@@ -300,15 +300,9 @@ public class CMDIParserVTDXML implements CMDIDataProcessor {
             }
             final String value = nav.toString(index);
             final String languageCode = extractLanguageCode(nav);
-
-            for(String postprocessedValue : postProcess(config.getName(), value, cmdiData)) {
-                // ignore non-English language names for facet LANGUAGE_CODE
-                if (config.getName().equals(FacetConstants.FIELD_LANGUAGE_CODE) && !languageCode.equals("code:eng") && !languageCode.equals(DEFAULT_LANGUAGE)) {
-                    continue;
-                }
-
-                valueLangPairList.add(new ImmutablePair<>(postprocessedValue, languageCode));
-            }
+            
+            final List<String> postProcessed = postProcess(config.getName(), value, cmdiData);
+            addValuesToList(config.getName(), postProcessed, valueLangPairList, languageCode);
             index = ap.evalXPath();
         }
 
@@ -364,6 +358,16 @@ public class CMDIParserVTDXML implements CMDIDataProcessor {
         }
 
         return postProcessors.get(FacetConstants.FIELD_LANGUAGE_CODE).process(languageCode, null).get(0);
+    }
+
+    private void addValuesToList(String facetName, final List<String> values, List<Pair<String, String>> valueLangPairList, final String languageCode) {
+        for (String value : values) {
+            // ignore non-English language names for facet LANGUAGE_CODE
+            if (facetName.equals(FacetConstants.FIELD_LANGUAGE_CODE) && !languageCode.equals("code:eng") && !languageCode.equals(DEFAULT_LANGUAGE)) {
+                continue;
+            }
+            valueLangPairList.add(new ImmutablePair<>(value, languageCode));
+        }
     }
 
     private void insertFacetValues(String name, List<Pair<String, String>> valueLangPairList, CMDIData cmdiData, boolean allowMultipleValues, boolean caseInsensitive) {

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIParserVTDXML.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CMDIParserVTDXML.java
@@ -92,8 +92,8 @@ public class CMDIParserVTDXML implements CMDIDataProcessor {
      */
     private void setNameSpace(AutoPilot ap, String profileId) {
         ap.declareXPathNameSpace("cmd", "http://www.clarin.eu/cmd/1");
-        if(profileId != null) {
-            ap.declareXPathNameSpace("cmdp", "http://www.clarin.eu/cmd/1/profiles/"+profileId);
+        if (profileId != null) {
+            ap.declareXPathNameSpace("cmdp", "http://www.clarin.eu/cmd/1/profiles/" + profileId);
         }
     }
 
@@ -170,7 +170,7 @@ public class CMDIParserVTDXML implements CMDIDataProcessor {
         if (index != -1) {
             String schemaLocation = nav.toNormalizedString(index);
             String[] schemaLocationArray = schemaLocation.split(" ");
-            result = schemaLocationArray[schemaLocationArray.length-1];
+            result = schemaLocationArray[schemaLocationArray.length - 1];
         } else {
             index = nav.getAttrValNS("http://www.w3.org/2001/XMLSchema-instance", "noNamespaceSchemaLocation");
             if (index != -1) {
@@ -300,15 +300,16 @@ public class CMDIParserVTDXML implements CMDIDataProcessor {
             }
             final String value = nav.toString(index);
             final String languageCode = extractLanguageCode(nav);
-            
+
             final List<String> postProcessed = postProcess(config.getName(), value, cmdiData);
             addValuesToList(config.getName(), postProcessed, valueLangPairList, languageCode);
             index = ap.evalXPath();
         }
 
         // return if no result was found or accepted
-        if(!matchedPattern || valueLangPairList.isEmpty())
+        if (!matchedPattern || valueLangPairList.isEmpty()) {
             return matchedPattern;
+        }
 
         // decide what extracted values should be taken
         List<Pair<String, String>> finalValueLangPairList = valueLangPairList;
@@ -317,9 +318,9 @@ public class CMDIParserVTDXML implements CMDIDataProcessor {
             finalValueLangPairList = new ArrayList<>();
             if (config.getName().equals(FacetConstants.FIELD_NAME)) {
                 int counter = 0;
-                for(int i = 0; i < valueLangPairList.size(); i++) {
+                for (int i = 0; i < valueLangPairList.size(); i++) {
                     Pair<String, String> valueLangPair = valueLangPairList.get(i);
-                    if(valueLangPair.getRight().equals("code:eng")){
+                    if (valueLangPair.getRight().equals("code:eng")) {
                         counter = i;
                         break;
                     }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/ContinentNamePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/ContinentNamePostProcessor.java
@@ -7,29 +7,35 @@ import java.util.Map;
 
 public class ContinentNamePostProcessor implements PostProcessor {
 
-	private static Map<String, String> continentCodeMap;
-	static {
-		continentCodeMap = new HashMap<String, String>();
-		continentCodeMap.put("AF", "Africa");
-		continentCodeMap.put("AS", "Asia");
-		continentCodeMap.put("EU", "Europe");
-		continentCodeMap.put("NA", "North America");
-		continentCodeMap.put("SA", "South America");
-		continentCodeMap.put("OC", "Oceania");
-		continentCodeMap.put("AN", "Antarctica");
-	}
+    private static Map<String, String> continentCodeMap;
 
-	/**
-	 * Replaces two-letter continent codes with continent names
-	 */
-	@Override
-	public List<String> process(final String value, CMDIData cmdiData) {
-            List<String> resultList = new ArrayList<String>();
-            if(value != null && continentCodeMap.keySet().contains(value)) {
-                resultList.add(continentCodeMap.get(value));
-            } else {
-                resultList.add(value);
-            }
-            return resultList;
-	}
+    static {
+        continentCodeMap = new HashMap<String, String>();
+        continentCodeMap.put("AF", "Africa");
+        continentCodeMap.put("AS", "Asia");
+        continentCodeMap.put("EU", "Europe");
+        continentCodeMap.put("NA", "North America");
+        continentCodeMap.put("SA", "South America");
+        continentCodeMap.put("OC", "Oceania");
+        continentCodeMap.put("AN", "Antarctica");
+    }
+
+    /**
+     * Replaces two-letter continent codes with continent names
+     */
+    @Override
+    public List<String> process(final String value, CMDIData cmdiData) {
+        List<String> resultList = new ArrayList<String>();
+        if (value != null && continentCodeMap.keySet().contains(value)) {
+            resultList.add(continentCodeMap.get(value));
+        } else {
+            resultList.add(value);
+        }
+        return resultList;
+    }
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
+    }
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/ContinentNamePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/ContinentNamePostProcessor.java
@@ -23,7 +23,7 @@ public class ContinentNamePostProcessor implements PostProcessor {
 	 * Replaces two-letter continent codes with continent names
 	 */
 	@Override
-	public List<String> process(final String value) {
+	public List<String> process(final String value, CMDIData cmdiData) {
             List<String> resultList = new ArrayList<String>();
             if(value != null && continentCodeMap.keySet().contains(value)) {
                 resultList.add(continentCodeMap.get(value));

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CountryNamePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CountryNamePostProcessor.java
@@ -24,7 +24,7 @@ public class CountryNamePostProcessor implements PostProcessor {
      * @return List of country names
      */
     @Override
-    public List<String> process(String value) {
+    public List<String> process(String value, CMDIData cmdiData) {
         String result = value;
         if (result != null) {
             String name = getCountryCodeMap().get(value.toUpperCase());

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CountryNamePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/CountryNamePostProcessor.java
@@ -59,4 +59,9 @@ public class CountryNamePostProcessor implements PostProcessor {
         }
     }
 
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
+    }
+
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/FormatPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/FormatPostProcessor.java
@@ -15,7 +15,7 @@ public class FormatPostProcessor implements PostProcessor {
      * @return value if it is a valid MIMEtype or UNKNOWN_STRING otherwise
      */
     @Override
-    public List<String> process(String value) {
+    public List<String> process(String value, CMDIData cmdiData) {
         Matcher mimeTypeMatcher = MIMETYPE_PATTERN.matcher(value);
         List<String> resultList = new ArrayList<String>();
         

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/FormatPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/FormatPostProcessor.java
@@ -6,11 +6,13 @@ import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 
 public class FormatPostProcessor implements PostProcessor {
+
     private static final Pattern MIMETYPE_PATTERN = Pattern.compile("^(application|audio|example|image|message|model|multipart|text|video)/.*");
     private static final String UNKNOWN_STRING = "unknown type";
 
     /**
      * Returns value if it is a valid MIMEtype or UNKNOWN_STRING otherwise
+     *
      * @param value potential MIMEType value
      * @return value if it is a valid MIMEtype or UNKNOWN_STRING otherwise
      */
@@ -18,12 +20,17 @@ public class FormatPostProcessor implements PostProcessor {
     public List<String> process(String value, CMDIData cmdiData) {
         Matcher mimeTypeMatcher = MIMETYPE_PATTERN.matcher(value);
         List<String> resultList = new ArrayList<String>();
-        
+
         if (mimeTypeMatcher.matches()) {
             resultList.add(value);
         } else {
             resultList.add(UNKNOWN_STRING);
         }
         return resultList;
+    }
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
     }
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/IdPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/IdPostProcessor.java
@@ -13,7 +13,7 @@ public class IdPostProcessor implements PostProcessor {
      * @return normalized version of value
      */
     @Override
-    public List<String> process(String value) {
+    public List<String> process(String value, CMDIData cmdiData) {
         List<String> resultList = new ArrayList<String>();
         resultList.add(StringUtils.normalizeIdString(value));
         return resultList;

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/IdPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/IdPostProcessor.java
@@ -18,4 +18,9 @@ public class IdPostProcessor implements PostProcessor {
         resultList.add(StringUtils.normalizeIdString(value));
         return resultList;
     }
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
+    }
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LanguageCodePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LanguageCodePostProcessor.java
@@ -11,60 +11,69 @@ import org.slf4j.LoggerFactory;
 import eu.clarin.cmdi.vlo.LanguageCodeUtils;
 import org.apache.commons.lang.WordUtils;
 
-public class LanguageCodePostProcessor extends PostProcessorsWithVocabularyMap{
+public class LanguageCodePostProcessor extends PostProcessorsWithVocabularyMap {
 
     private final static Logger LOG = LoggerFactory.getLogger(LanguageCodePostProcessor.class);
-    
+
     protected static final String CODE_PREFIX = "code:";
     protected static final String LANG_NAME_PREFIX = "name:";
     protected static final String ISO639_2_PREFIX = "ISO639-2:";
     protected static final String ISO639_3_PREFIX = "ISO639-3:";
     protected static final String SIL_CODE_PREFIX = "RFC1766:x-sil-";
     protected static final String SIL_CODE_PREFIX_alt = "RFC-1766:x-sil-";
-    
+
     private static final Pattern RFC1766_Pattern = Pattern.compile("^([a-z]{2,3})[-_][a-zA-Z]{2}$");
 
     /**
-     * Returns the language code based on the mapping defined in the CMDI components: See http://trac.clarin.eu/ticket/40 for the mapping.
-     * If no mapping is found the original value is returned.
-     * @param value extracted language value (language code or language name) from CMDI file
+     * Returns the language code based on the mapping defined in the CMDI
+     * components: See http://trac.clarin.eu/ticket/40 for the mapping. If no
+     * mapping is found the original value is returned.
+     *
+     * @param value extracted language value (language code or language name)
+     * from CMDI file
      * @return ISO 639-3 code
      */
     @Override
     public List<String> process(String value, CMDIData cmdiData) {
         List<String> resultList = new ArrayList<String>();
-        
-        if (value != null)
+
+        if (value != null) {
             resultList.add(extractLanguageCode(value));
-        else
+        } else {
             resultList.add(null);
+        }
         return resultList;
     }
-    
-	@Override
-	public String getNormalizationMapURL() {
-		return MetadataImporter.config.getLanguageNameVariantsUrl();
-	}
+
+    @Override
+    public String getNormalizationMapURL() {
+        return MetadataImporter.config.getLanguageNameVariantsUrl();
+    }
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
+    }
 
     protected String extractLanguageCode(String value) {
         final LanguageCodeUtils languageCodeUtils = MetadataImporter.languageCodeUtils;
         String result = value;
-        
+
         result = result.replaceFirst(ISO639_2_PREFIX, "").replaceFirst(ISO639_3_PREFIX, "").replaceFirst(SIL_CODE_PREFIX, "").replaceFirst(SIL_CODE_PREFIX_alt, "");
-        
+
         // map known language name variants to their offical name
         result = normalize(result, result);
-        
+
         // input is already ISO 639-3?
-        if(languageCodeUtils.getIso639ToLanguageNameMap().keySet().contains(result.toUpperCase())) {
+        if (languageCodeUtils.getIso639ToLanguageNameMap().keySet().contains(result.toUpperCase())) {
             return CODE_PREFIX + result.toLowerCase();
-        }        
+        }
         // input is 2-letter code -> map to ISO 639-3
-        if(languageCodeUtils.getSilToIso639Map().containsKey(result.toLowerCase())) {
+        if (languageCodeUtils.getSilToIso639Map().containsKey(result.toLowerCase())) {
             return CODE_PREFIX + languageCodeUtils.getSilToIso639Map().get(result.toLowerCase());
         }
 
-        if(languageCodeUtils.getLanguageNameToIso639Map().containsKey(WordUtils.capitalize(result))) { // (english) language name?
+        if (languageCodeUtils.getLanguageNameToIso639Map().containsKey(WordUtils.capitalize(result))) { // (english) language name?
             return CODE_PREFIX + languageCodeUtils.getLanguageNameToIso639Map().get(WordUtils.capitalize(result));
         }
 
@@ -72,15 +81,16 @@ public class LanguageCodePostProcessor extends PostProcessorsWithVocabularyMap{
         if (languageCodeUtils.getIso6392TToISO6393Map().containsKey(result.toLowerCase())) {
             return CODE_PREFIX + languageCodeUtils.getIso6392TToISO6393Map().get(result.toLowerCase());
         }
-        
+
         Matcher matcher = RFC1766_Pattern.matcher(result);
-        if(matcher.find()) {
+        if (matcher.find()) {
             return extractLanguageCode(matcher.group(1));
         }
-            
+
         // language code not identified? -> language name
-        if(!result.equals(""))
+        if (!result.equals("")) {
             result = LANG_NAME_PREFIX + WordUtils.capitalize(result);
+        }
         return result;
     }
 

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LanguageCodePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LanguageCodePostProcessor.java
@@ -31,7 +31,7 @@ public class LanguageCodePostProcessor extends PostProcessorsWithVocabularyMap{
      * @return ISO 639-3 code
      */
     @Override
-    public List<String> process(String value) {
+    public List<String> process(String value, CMDIData cmdiData) {
         List<String> resultList = new ArrayList<String>();
         
         if (value != null)

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LanguageNamePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LanguageNamePostProcessor.java
@@ -32,7 +32,7 @@ import java.util.List;
 class LanguageNamePostProcessor implements PostProcessor {
 
     @Override
-    public List<String> process(String value) {
+    public List<String> process(String value, CMDIData cmdiData) {
         if (value.startsWith(LANG_NAME_PREFIX)) {
             return returnName(value);
         } else if (value.startsWith(CODE_PREFIX)) {

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LanguageNamePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LanguageNamePostProcessor.java
@@ -43,6 +43,11 @@ class LanguageNamePostProcessor implements PostProcessor {
         }
     }
 
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
+    }
+
     /**
      *
      * @param value original value string with <em>code</em> prefix

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicensePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicensePostProcessor.java
@@ -16,4 +16,9 @@ public class LicensePostProcessor extends PostProcessorsWithVocabularyMap {
     public String getNormalizationMapURL() {
         return MetadataImporter.config.getLicenseURIMapUrl();
     }
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
+    }
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicensePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicensePostProcessor.java
@@ -7,7 +7,7 @@ import java.util.List;
 public class LicensePostProcessor extends PostProcessorsWithVocabularyMap {
 
     @Override
-    public List<String> process(String value) {
+    public List<String> process(String value, CMDIData cmdiData) {
         String normalizedVal = normalize(value);
         return normalizedVal != null ? Arrays.asList(normalizedVal) : new ArrayList<>();
     }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
@@ -14,7 +14,12 @@ public class LicenseTypePostProcessor extends PostProcessorsWithVocabularyMap {
     public List<String> process(final String value) {
         String normalizedVal = normalize(value);
         //Availability variants can be normalized with multiple values, in vocabulary they are separated with ;
-        return normalizedVal != null ? Arrays.asList(normalizedVal.split(";")) : new ArrayList<>();
+        if (normalizedVal != null) {
+            return Arrays.asList(normalizedVal.split(";"));
+        } else {
+            //TODO: take values from availability facet
+            return new ArrayList<>();
+        }
     }
 
     @Override

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
@@ -1,30 +1,64 @@
 package eu.clarin.cmdi.vlo.importer;
 
-import java.util.ArrayList;
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import eu.clarin.cmdi.vlo.FacetConstants;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 /**
- *
+ * Vocabulary map based post processing with a fallback that transfers values
+ * from the availability facet.
+ * 
+ * See {@link  https://github.com/clarin-eric/VLO/issues/39} and {@link https://github.com/clarin-eric/VLO/issues/55}
  * @author Twan Goosen
  */
 public class LicenseTypePostProcessor extends PostProcessorsWithVocabularyMap {
 
+    public static final ImmutableList<String> LICENSE_TYPE_VALUES = ImmutableList.of(
+            FacetConstants.AVAILABILITY_LEVEL_PUB,
+            FacetConstants.AVAILABILITY_LEVEL_ACA,
+            FacetConstants.AVAILABILITY_LEVEL_RES);
+
     @Override
     public List<String> process(final String value, CMDIData cmdiData) {
-        if(value == null) {
-            //TODO: take values from availability facet
-            return Collections.emptyList();
+        if (value != null) {
+            final String normalizedVal = normalize(value);
+            //Availability variants can be normalized with multiple values, in vocabulary they are separated with ;
+            if (normalizedVal != null) {
+                return Arrays.asList(normalizedVal.split(";"));
+            }
         }
-        String normalizedVal = normalize(value);
-        //Availability variants can be normalized with multiple values, in vocabulary they are separated with ;
-        if (normalizedVal != null) {
-            return Arrays.asList(normalizedVal.split(";"));
-        } else {
-            //TODO: take values from availability facet
-            return new ArrayList<>();
+        //no (normalized) value - get from availability facet
+        return transferValuesFromAvailability(cmdiData);
+    }
+
+    /**
+     * Transfers license type values from the availability facet - meant as a fallback
+     * @param cmdiData
+     * @return 
+     */
+    private List<String> transferValuesFromAvailability(CMDIData cmdiData) {
+        if (cmdiData != null) {
+            final Collection<Object> availabilityValues = cmdiData.getDocField(FacetConstants.FIELD_AVAILABILITY);
+            if (availabilityValues != null) {
+                //turn into string list
+                final List<String> values = Lists.newArrayList(Collections2.transform(availabilityValues, new Function<Object, String>() {
+                    @Override
+                    public String apply(Object t) {
+                        return t.toString();
+                    }
+                }));
+                //only transfer 'valid' license type values (pub, aca, res)
+                values.retainAll(LICENSE_TYPE_VALUES);
+                return values;
+            }
         }
+        return Collections.emptyList();
     }
 
     @Override

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
@@ -26,4 +26,9 @@ public class LicenseTypePostProcessor extends PostProcessorsWithVocabularyMap {
     public String getNormalizationMapURL() {
         return MetadataImporter.config.getLicenseTypeMapUrl();
     }
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return true;
+    }
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
@@ -19,11 +19,6 @@ import java.util.List;
  */
 public class LicenseTypePostProcessor extends PostProcessorsWithVocabularyMap {
 
-    public static final ImmutableList<String> LICENSE_TYPE_VALUES = ImmutableList.of(
-            FacetConstants.AVAILABILITY_LEVEL_PUB,
-            FacetConstants.AVAILABILITY_LEVEL_ACA,
-            FacetConstants.AVAILABILITY_LEVEL_RES);
-
     @Override
     public List<String> process(final String value, CMDIData cmdiData) {
         if (value != null) {
@@ -54,7 +49,7 @@ public class LicenseTypePostProcessor extends PostProcessorsWithVocabularyMap {
                     }
                 }));
                 //only transfer 'valid' license type values (pub, aca, res)
-                values.retainAll(LICENSE_TYPE_VALUES);
+                values.retainAll(FacetConstants.LICENSE_TYPE_VALUES);
                 return values;
             }
         }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class LicenseTypePostProcessor extends PostProcessorsWithVocabularyMap {
 
     @Override
-    public List<String> process(final String value) {
+    public List<String> process(final String value, CMDIData cmdiData) {
         String normalizedVal = normalize(value);
         //Availability variants can be normalized with multiple values, in vocabulary they are separated with ;
         if (normalizedVal != null) {

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
@@ -1,0 +1,24 @@
+package eu.clarin.cmdi.vlo.importer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ *
+ * @author Twan Goosen
+ */
+public class LicenseTypePostProcessor extends PostProcessorsWithVocabularyMap {
+
+    @Override
+    public List<String> process(final String value) {
+        String normalizedVal = normalize(value);
+        //Availability variants can be normalized with multiple values, in vocabulary they are separated with ;
+        return normalizedVal != null ? Arrays.asList(normalizedVal.split(";")) : new ArrayList<>();
+    }
+
+    @Override
+    public String getNormalizationMapURL() {
+        return MetadataImporter.config.getLicenseTypeMapUrl();
+    }
+}

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessor.java
@@ -2,6 +2,7 @@ package eu.clarin.cmdi.vlo.importer;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -12,6 +13,10 @@ public class LicenseTypePostProcessor extends PostProcessorsWithVocabularyMap {
 
     @Override
     public List<String> process(final String value, CMDIData cmdiData) {
+        if(value == null) {
+            //TODO: take values from availability facet
+            return Collections.emptyList();
+        }
         String normalizedVal = normalize(value);
         //Availability variants can be normalized with multiple values, in vocabulary they are separated with ;
         if (normalizedVal != null) {

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/MetadataImporter.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/MetadataImporter.java
@@ -88,7 +88,7 @@ public class MetadataImporter {
         POST_PROCESSORS.put(FacetConstants.FIELD_LANGUAGE_CODE, new LanguageCodePostProcessor());
         POST_PROCESSORS.put(FacetConstants.FIELD_LANGUAGE_NAME, new LanguageNamePostProcessor());
         POST_PROCESSORS.put(FacetConstants.FIELD_AVAILABILITY, new AvailabilityPostProcessor());
-        POST_PROCESSORS.put(FacetConstants.FIELD_LICENSE_TYPE, new AvailabilityPostProcessor());
+        POST_PROCESSORS.put(FacetConstants.FIELD_LICENSE_TYPE, new LicenseTypePostProcessor());
         POST_PROCESSORS.put(FacetConstants.FIELD_ORGANISATION, new OrganisationPostProcessor());
         POST_PROCESSORS.put(FacetConstants.FIELD_TEMPORAL_COVERAGE, new TemporalCoveragePostProcessor());
         POST_PROCESSORS.put(FacetConstants.FIELD_NATIONAL_PROJECT, new NationalProjectPostProcessor());

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/MetadataImporter.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/MetadataImporter.java
@@ -88,6 +88,7 @@ public class MetadataImporter {
         POST_PROCESSORS.put(FacetConstants.FIELD_LANGUAGE_CODE, new LanguageCodePostProcessor());
         POST_PROCESSORS.put(FacetConstants.FIELD_LANGUAGE_NAME, new LanguageNamePostProcessor());
         POST_PROCESSORS.put(FacetConstants.FIELD_AVAILABILITY, new AvailabilityPostProcessor());
+        POST_PROCESSORS.put(FacetConstants.FIELD_LICENSE_TYPE, new AvailabilityPostProcessor());
         POST_PROCESSORS.put(FacetConstants.FIELD_ORGANISATION, new OrganisationPostProcessor());
         POST_PROCESSORS.put(FacetConstants.FIELD_TEMPORAL_COVERAGE, new TemporalCoveragePostProcessor());
         POST_PROCESSORS.put(FacetConstants.FIELD_NATIONAL_PROJECT, new NationalProjectPostProcessor());

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/MetadataImporter.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/MetadataImporter.java
@@ -509,7 +509,7 @@ public class MetadataImporter {
             }
 
             FormatPostProcessor processor = new FormatPostProcessor();
-            mimeType = processor.process(mimeType).get(0);
+            mimeType = processor.process(mimeType, null).get(0);
 
             // TODO check should probably be moved into Solr (by using some minimum length filter)
             if (!mimeType.equals("")) {

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/NamePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/NamePostProcessor.java
@@ -30,7 +30,7 @@ public class NamePostProcessor implements PostProcessor {
     private static final Pattern OMIT_QUOTES_PATTERN = Pattern.compile("^([\"\'“])(.*)\\1$");
 
     @Override
-    public List<String> process(String value) {
+    public List<String> process(String value, CMDIData cmdiData) {
         Matcher nameMatcher = OMIT_QUOTES_PATTERN.matcher(value);
         List<String> resultList = new ArrayList<>();
         

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/NamePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/NamePostProcessor.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
  * @author Thomas Eckart
  */
 public class NamePostProcessor implements PostProcessor {
+
     // omit leading and trailing quote characters if they are equal
     private static final Pattern OMIT_QUOTES_PATTERN = Pattern.compile("^([\"\'“])(.*)\\1$");
 
@@ -33,13 +34,19 @@ public class NamePostProcessor implements PostProcessor {
     public List<String> process(String value, CMDIData cmdiData) {
         Matcher nameMatcher = OMIT_QUOTES_PATTERN.matcher(value);
         List<String> resultList = new ArrayList<>();
-        
-        if(nameMatcher.matches())
+
+        if (nameMatcher.matches()) {
             resultList.add(nameMatcher.group(2));
-        else
+        } else {
             resultList.add(value);
-        
+        }
+
         return resultList;
     }
-    
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
+    }
+
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/NationalProjectPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/NationalProjectPostProcessor.java
@@ -25,7 +25,7 @@ public class NationalProjectPostProcessor extends PostProcessorsWithVocabularyMa
      * @return
      */
     @Override
-    public List<String> process(String value) {
+    public List<String> process(String value, CMDIData cmdiData) {
     	return Arrays.asList(normalize(value.trim(), ""));
     }
     

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/NationalProjectPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/NationalProjectPostProcessor.java
@@ -26,13 +26,17 @@ public class NationalProjectPostProcessor extends PostProcessorsWithVocabularyMa
      */
     @Override
     public List<String> process(String value, CMDIData cmdiData) {
-    	return Arrays.asList(normalize(value.trim(), ""));
+        return Arrays.asList(normalize(value.trim(), ""));
     }
-    
 
-	@Override
-	public String getNormalizationMapURL() {
-		return MetadataImporter.config.getNationalProjectMapping();
-	}
-    
+    @Override
+    public String getNormalizationMapURL() {
+        return MetadataImporter.config.getNationalProjectMapping();
+    }
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
+    }
+
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/OrganisationPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/OrganisationPostProcessor.java
@@ -15,7 +15,7 @@ public class OrganisationPostProcessor extends PostProcessorsWithVocabularyMap {
      * replaced with controlled vocabulary
      */
     @Override
-    public List<String> process(String value) {
+    public List<String> process(String value, CMDIData cmdiData) {
 
         String[] splitArray = normalizeInputString(value).split(";");
         for (int i = 0; i < splitArray.length; i++) {

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/OrganisationPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/OrganisationPostProcessor.java
@@ -39,4 +39,9 @@ public class OrganisationPostProcessor extends PostProcessorsWithVocabularyMap {
     private String normalizeVariant(String key) {
         return key.toLowerCase().replaceAll("-", " ");
     }
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
+    }
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/PostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/PostProcessor.java
@@ -5,19 +5,26 @@ import java.util.List;
 /**
  * Defines the interface for a postprocessor.
  *
- * Such a postprossor is called on a single facet value after this facet value is inserted into the solr document during import.
+ * Such a postprossor is called on a single facet value after this facet value
+ * is inserted into the solr document during import.
  *
- * at the start of MetadataImporter which postprocessors (if any) are used for which facet are defined.
+ * at the start of MetadataImporter which postprocessors (if any) are used for
+ * which facet are defined.
  */
-
 public interface PostProcessor {
 
-    public List<String> process(String value, CMDIData cmdiData);
-    
     /**
-     * 
-     * @return whether the postprocessor should also be called in case
-     * no matching value was found (with <pre>value == null</pre>)
+     *
+     * @param value value to post-process; can be null
+     * @param cmdiData processing context, can be null or incomplete
+     * @return list of post-processed values
+     */
+    public List<String> process(String value, CMDIData cmdiData);
+
+    /**
+     *
+     * @return whether the postprocessor should also be called in case no
+     * matching value was found (with <pre>value == null</pre>)
      */
     public boolean doesProcessNoValue();
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/PostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/PostProcessor.java
@@ -12,6 +12,6 @@ import java.util.List;
 
 public interface PostProcessor {
 
-    public List<String> process(String value);
+    public List<String> process(String value, CMDIData cmdiData);
 
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/PostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/PostProcessor.java
@@ -13,5 +13,11 @@ import java.util.List;
 public interface PostProcessor {
 
     public List<String> process(String value, CMDIData cmdiData);
-
+    
+    /**
+     * 
+     * @return whether the postprocessor should also be called in case
+     * no matching value was found (with <pre>value == null</pre>)
+     */
+    public boolean doesProcessNoValue();
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/ResourceClassPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/ResourceClassPostProcessor.java
@@ -4,24 +4,31 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ResourceClassPostProcessor implements PostProcessor {
+
     /**
      * Postprocess ResourceClass values
+     *
      * @param value extracted ResourcClass information
      * @return Value with upper case first letter and some value normalisation
      */
     @Override
     public List<String> process(String value, CMDIData cmdiData) {
         String result = value;
-        
+
         // replace DCMI URLs with DCMI type
         result = result.replaceFirst("http://purl.org/dc/dcmitype/", "");
-        
+
         // first letter should be upper case
-        if(result.length() > 1) {
+        if (result.length() > 1) {
             result = result.substring(0, 1).toUpperCase().concat(result.substring(1, result.length()));
         }
         List<String> resultList = new ArrayList<String>();
         resultList.add(result);
         return resultList;
+    }
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
     }
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/ResourceClassPostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/ResourceClassPostProcessor.java
@@ -10,7 +10,7 @@ public class ResourceClassPostProcessor implements PostProcessor {
      * @return Value with upper case first letter and some value normalisation
      */
     @Override
-    public List<String> process(String value) {
+    public List<String> process(String value, CMDIData cmdiData) {
         String result = value;
         
         // replace DCMI URLs with DCMI type

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/TemporalCoveragePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/TemporalCoveragePostProcessor.java
@@ -21,7 +21,7 @@ public class TemporalCoveragePostProcessor implements PostProcessor {
     @Override
     public List<String> process(final String value, CMDIData cmdiData) {
         String coverageString = value.trim();
-        
+
         Matcher odrfMatcher = ODRF_PATTERN.matcher(coverageString);
         Matcher yearMatcher = DATETIME_PATTERN.matcher(coverageString);
         List<String> resultList = new ArrayList<String>();
@@ -33,5 +33,10 @@ public class TemporalCoveragePostProcessor implements PostProcessor {
         }
 
         return resultList;
+    }
+
+    @Override
+    public boolean doesProcessNoValue() {
+        return false;
     }
 }

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/TemporalCoveragePostProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/TemporalCoveragePostProcessor.java
@@ -19,7 +19,7 @@ public class TemporalCoveragePostProcessor implements PostProcessor {
      * @return List of accepted values
      */
     @Override
-    public List<String> process(final String value) {
+    public List<String> process(final String value, CMDIData cmdiData) {
         String coverageString = value.trim();
         
         Matcher odrfMatcher = ODRF_PATTERN.matcher(coverageString);

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/VLOMarshaller.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/VLOMarshaller.java
@@ -27,6 +27,7 @@ public class VLOMarshaller {
      * @return the facet concept mapping
      */
     public static FacetConceptMapping getFacetConceptMapping(String facetConcepts) {
+        //TODO: cache results
         final MappingDefinitionResolver mappingDefinitionResolver
                 = new MappingDefinitionResolver(VLOMarshaller.class);
 

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/VLOMarshaller.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/VLOMarshaller.java
@@ -7,6 +7,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -20,33 +22,38 @@ public class VLOMarshaller {
 
     private final static Logger logger = LoggerFactory.getLogger(VLOMarshaller.class);
 
+    private final static Map<String, FacetConceptMapping> MAPPING_CACHE = new ConcurrentHashMap<>();
+
     /**
-     * Get facet concepts mapping from a facet concept mapping file
+     * Get facet concepts mapping from a facet concept mapping file. Unmarshalled
+     * mappings are cached statically for this class.
      *
      * @param facetConcepts name of the facet concepts file
      * @return the facet concept mapping
      */
     public static FacetConceptMapping getFacetConceptMapping(String facetConcepts) {
-        //TODO: cache results
-        final MappingDefinitionResolver mappingDefinitionResolver
-                = new MappingDefinitionResolver(VLOMarshaller.class);
+        if (!MAPPING_CACHE.containsKey(facetConcepts)) {
+            // unmarshall map for file
+            final MappingDefinitionResolver mappingDefinitionResolver
+                    = new MappingDefinitionResolver(VLOMarshaller.class);
 
-        FacetConceptMapping result;
-        InputStream is = null;
+            FacetConceptMapping result;
+            InputStream is = null;
 
-        try {
-            is = (facetConcepts == null || "".equals(facetConcepts))
-                    ? VLOMarshaller.class.getResourceAsStream(VloConfig.DEFAULT_FACET_CONCEPTS_RESOURCE_FILE)
-                    : mappingDefinitionResolver.tryResolveUrlFileOrResourceStream(facetConcepts);
-        } catch (FileNotFoundException e) {
-            logger.error("Could not find facets file: {}", facetConcepts);
-            return null;
-        } catch (IOException e) {
-            logger.error("Could not process facets file: {}", facetConcepts);
-            return null;
+            try {
+                is = (facetConcepts == null || "".equals(facetConcepts))
+                        ? VLOMarshaller.class.getResourceAsStream(VloConfig.DEFAULT_FACET_CONCEPTS_RESOURCE_FILE)
+                        : mappingDefinitionResolver.tryResolveUrlFileOrResourceStream(facetConcepts);
+            } catch (FileNotFoundException e) {
+                logger.error("Could not find facets file: {}", facetConcepts);
+                return null;
+            } catch (IOException e) {
+                logger.error("Could not process facets file: {}", facetConcepts);
+                return null;
+            }
+            MAPPING_CACHE.put(facetConcepts, unmarshal(is));
         }
-
-        return unmarshal(is);
+        return MAPPING_CACHE.get(facetConcepts);
     }
 
     /**

--- a/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/AvailabilityPostProcessorTest.java
+++ b/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/AvailabilityPostProcessorTest.java
@@ -15,18 +15,18 @@ public class AvailabilityPostProcessorTest extends ImporterTestcase {
         List<String> normalizedVals;
         
         //"Apache Licence 2.0" -> "PUB;BY"
-        normalizedVals = processor.process("Apache Licence 2.0");
+        normalizedVals = processor.process("Apache Licence 2.0", null);
         assertEquals(2, normalizedVals.size());
         assertEquals("PUB", normalizedVals.get(0));
         assertEquals("BY", normalizedVals.get(1));
-        assertEquals("PUB", processor.process("Open Access").get(0));
-        assertEquals("PUB", processor.process("open access").get(0));
-        assertEquals("PUB", processor.process("Open Access").get(0));
-        assertEquals("ACA", processor.process("free; Free for academic use.").get(0));
-        assertEquals("RES", processor.process("Please contact contact-person").get(0));
+        assertEquals("PUB", processor.process("Open Access", null).get(0));
+        assertEquals("PUB", processor.process("open access", null).get(0));
+        assertEquals("PUB", processor.process("Open Access", null).get(0));
+        assertEquals("ACA", processor.process("free; Free for academic use.", null).get(0));
+        assertEquals("RES", processor.process("Please contact contact-person", null).get(0));
      
         //"GNU General Public License, version 3" -> "PUB;BY;SA"
-        normalizedVals = processor.process("GNU General Public License, version 3");
+        normalizedVals = processor.process("GNU General Public License, version 3", null);
         assertEquals(3, normalizedVals.size());
         assertEquals("PUB", normalizedVals.get(0));
         assertEquals("BY", normalizedVals.get(1));

--- a/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/CountryNamePostProcessorTest.java
+++ b/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/CountryNamePostProcessorTest.java
@@ -19,11 +19,11 @@ public class CountryNamePostProcessorTest extends ImporterTestcase {
     @Test
     public void testCountryCode() {
         CountryNamePostProcessor processor = new CountryNamePostProcessor();
-        assertEquals("Netherlands", processor.process("NL").get(0));
-        assertEquals("United Kingdom", processor.process("GB").get(0));
-        assertEquals("Netherlands", processor.process("nl").get(0));
-        assertEquals("test", processor.process("test").get(0));
-        assertEquals("", processor.process("").get(0));
-        assertEquals(null, processor.process(null).get(0));
+        assertEquals("Netherlands", processor.process("NL", null).get(0));
+        assertEquals("United Kingdom", processor.process("GB", null).get(0));
+        assertEquals("Netherlands", processor.process("nl", null).get(0));
+        assertEquals("test", processor.process("test", null).get(0));
+        assertEquals("", processor.process("", null).get(0));
+        assertEquals(null, processor.process(null, null).get(0));
     }
 }

--- a/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/FacetMappingFactoryTest.java
+++ b/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/FacetMappingFactoryTest.java
@@ -30,7 +30,7 @@ public class FacetMappingFactoryTest {
                 .getFacetMapping(FACETCONCEPTS_FILENAME, IMDI_PROFILE_ID, true);
 
         List<FacetConfiguration> facets = facetMapping.getFacets();
-        assertEquals(20, facets.size());
+        assertEquals(21, facets.size());
 
         int index = 0;
         FacetConfiguration mapping = facets.get(index++);
@@ -165,6 +165,13 @@ public class FacetMappingFactoryTest {
         assertEquals("/cmd:CMD/cmd:Components/cmdp:mods/cmdp:classification/text()",
                 mapping.getFallbackPatterns().get(0));
         assertEquals(3, mapping.getFallbackPatterns().size());
+        mapping = facets.get(index++);
+
+        // test license facet mapping
+        assertEquals(FacetConstants.FIELD_LICENSE, mapping.getName());
+        assertEquals("/cmd:CMD/cmd:Components/cmdp:Session/cmdp:Resources/cmdp:MediaFile/cmdp:Access/cmdp:Availability/text()",
+                mapping.getPatterns().get(0));
+        assertEquals(4, mapping.getPatterns().size());
 
         assertEquals("check to see we tested them all", facets.size(), index);
     }
@@ -175,7 +182,7 @@ public class FacetMappingFactoryTest {
                 .getFacetMapping(FACETCONCEPTS_FILENAME, OLAC_PROFILE_ID, true);
 
         List<FacetConfiguration> facets = facetMapping.getFacets();
-        assertEquals(18, facets.size());
+        assertEquals(19, facets.size());
 
         int index = 0;
         FacetConfiguration mapping = facets.get(index++);
@@ -288,7 +295,14 @@ public class FacetMappingFactoryTest {
         assertEquals("/cmd:CMD/cmd:Components/cmdp:mods/cmdp:classification/text()",
                 mapping.getFallbackPatterns().get(0));
         assertEquals(3, mapping.getFallbackPatterns().size());
+        mapping = facets.get(index++);
 
+        // test license facet mapping
+        assertEquals(FacetConstants.FIELD_LICENSE, mapping.getName());
+        assertEquals("/cmd:CMD/cmd:Components/cmdp:OLAC-DcmiTerms/cmdp:license/text()",
+                mapping.getPatterns().get(0));
+        assertEquals(3, mapping.getPatterns().size());
+        
         assertEquals("check to see we tested them all", facets.size(), index);
     }
 
@@ -298,7 +312,7 @@ public class FacetMappingFactoryTest {
                 .getFacetMapping(FACETCONCEPTS_FILENAME, LRT_PROFILE_ID, true);
 
         List<FacetConfiguration> facets = facetMapping.getFacets();
-        assertEquals(17, facets.size());
+        assertEquals(19, facets.size());
 
         int index = 0;
         FacetConfiguration mapping = facets.get(index++);
@@ -415,6 +429,21 @@ public class FacetMappingFactoryTest {
                 mapping.getPatterns().get(0));
         assertEquals("/cmd:CMD/cmd:Components/cmdp:mods/cmdp:classification/text()",
                 mapping.getFallbackPatterns().get(0));
+        
+        mapping = facets.get(index++);
+        // test license type facet mapping
+        assertEquals(FacetConstants.FIELD_LICENSE_TYPE, mapping.getName());
+        assertEquals("/cmd:CMD/cmd:Components/cmdp:LrtInventoryResource/cmdp:LrtDistributionClassification/cmdp:DistributionType/text()",
+                mapping.getPatterns().get(0));
+        assertEquals(1, mapping.getPatterns().size());
+        
+        mapping = facets.get(index++);
+        // test license facet mapping
+        assertEquals(FacetConstants.FIELD_LICENSE, mapping.getName());
+        assertEquals("/cmd:CMD/cmd:Components/cmdp:LrtInventoryResource/cmdp:LrtIPR/cmdp:LicenseType/text()",
+                mapping.getPatterns().get(0));
+        assertEquals(2, mapping.getPatterns().size());
+        
         assertEquals("check to see we tested them all", facets.size(), index);
     }
 

--- a/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/LanguageCodePostProcessorTest.java
+++ b/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/LanguageCodePostProcessorTest.java
@@ -19,23 +19,23 @@ public class LanguageCodePostProcessorTest extends ImporterTestcase {
     @Test
     public void testLanguageCode() {
         PostProcessor processor = new LanguageCodePostProcessor();
-        assertEquals("code:nld", processor.process("NL").get(0));
-        assertEquals("code:eng", processor.process("en").get(0));
-        assertEquals("code:fry", processor.process("fry").get(0));
-        assertEquals("name:Test", processor.process("test").get(0));
-        assertEquals("", processor.process("").get(0));
-        assertEquals(null, processor.process(null).get(0));
-        assertEquals("code:fra", processor.process("ISO639-3:fra").get(0));
-        assertEquals("code:deu", processor.process("RFC1766:x-sil-GER").get(0));
-        assertEquals("name:RFC1766:sgn-NL", processor.process("RFC1766:sgn-NL").get(0));
-        assertEquals("code:eus", processor.process("baq").get(0));
-        assertEquals("code:eng", processor.process("eng").get(0));
-        assertEquals("code:eng", processor.process("English").get(0));
-        assertEquals("code:esn", processor.process("Salvadoran Sign Language").get(0));
-        assertEquals("code:eng", processor.process("en_US").get(0));
-        assertEquals("code:nld", processor.process("nl-NL").get(0));
-	assertEquals("code:eng", processor.process("ISO639-2:eng").get(0));
-        assertEquals("code:spa", processor.process("Spanish, Castilian").get(0));
-        assertEquals("code:ron", processor.process("Romanian").get(0));
+        assertEquals("code:nld", processor.process("NL", null).get(0));
+        assertEquals("code:eng", processor.process("en", null).get(0));
+        assertEquals("code:fry", processor.process("fry", null).get(0));
+        assertEquals("name:Test", processor.process("test", null).get(0));
+        assertEquals("", processor.process("", null).get(0));
+        assertEquals(null, processor.process(null, null).get(0));
+        assertEquals("code:fra", processor.process("ISO639-3:fra", null).get(0));
+        assertEquals("code:deu", processor.process("RFC1766:x-sil-GER", null).get(0));
+        assertEquals("name:RFC1766:sgn-NL", processor.process("RFC1766:sgn-NL", null).get(0));
+        assertEquals("code:eus", processor.process("baq", null).get(0));
+        assertEquals("code:eng", processor.process("eng", null).get(0));
+        assertEquals("code:eng", processor.process("English", null).get(0));
+        assertEquals("code:esn", processor.process("Salvadoran Sign Language", null).get(0));
+        assertEquals("code:eng", processor.process("en_US", null).get(0));
+        assertEquals("code:nld", processor.process("nl-NL", null).get(0));
+	assertEquals("code:eng", processor.process("ISO639-2:eng", null).get(0));
+        assertEquals("code:spa", processor.process("Spanish, Castilian", null).get(0));
+        assertEquals("code:ron", processor.process("Romanian", null).get(0));
     }
 }

--- a/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessorTest.java
+++ b/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessorTest.java
@@ -28,7 +28,7 @@ public class LicenseTypePostProcessorTest extends ImporterTestcase {
 
     private void assertMapping(String value, String... target) {
         List<String> normalizedVals;
-        normalizedVals = processor.process(value);
+        normalizedVals = processor.process(value, null);
         assertEquals(target.length, normalizedVals.size());
         for (int i = 0; i < target.length; i++) {
             assertEquals(target[i], normalizedVals.get(i));

--- a/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessorTest.java
+++ b/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessorTest.java
@@ -3,23 +3,35 @@ package eu.clarin.cmdi.vlo.importer;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
+import org.junit.Before;
 
 import org.junit.Test;
 
 public class LicenseTypePostProcessorTest extends ImporterTestcase {
-    
+
+    private LicenseTypePostProcessor processor;
+
+    @Before
+    public void setUp() {
+        processor = new LicenseTypePostProcessor();
+    }
 
     @Test
     public void testLanguageCode() {
-        PostProcessor processor = new LicenseTypePostProcessor();    
+        assertMapping("public", "PUB");
+        assertMapping("CLARIN-PUB", "PUB");
+        assertMapping("academic", "ACA");
+        assertMapping("CLARIN-ACA", "ACA");
+        assertMapping("restricted", "RES");
+        assertMapping("CLARIN-RES", "RES");
+    }
+
+    private void assertMapping(String value, String... target) {
         List<String> normalizedVals;
-        
-        normalizedVals = processor.process("public");
-        assertEquals(1, normalizedVals.size());
-        assertEquals("PUB", normalizedVals.get(0));
-     
-        normalizedVals = processor.process("academic");
-        assertEquals(1, normalizedVals.size());
-        assertEquals("ACA", normalizedVals.get(0));
+        normalizedVals = processor.process(value);
+        assertEquals(target.length, normalizedVals.size());
+        for (int i = 0; i < target.length; i++) {
+            assertEquals(target[i], normalizedVals.get(i));
+        }
     }
 }

--- a/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessorTest.java
+++ b/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/LicenseTypePostProcessorTest.java
@@ -1,0 +1,25 @@
+package eu.clarin.cmdi.vlo.importer;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class LicenseTypePostProcessorTest extends ImporterTestcase {
+    
+
+    @Test
+    public void testLanguageCode() {
+        PostProcessor processor = new LicenseTypePostProcessor();    
+        List<String> normalizedVals;
+        
+        normalizedVals = processor.process("public");
+        assertEquals(1, normalizedVals.size());
+        assertEquals("PUB", normalizedVals.get(0));
+     
+        normalizedVals = processor.process("academic");
+        assertEquals(1, normalizedVals.size());
+        assertEquals("ACA", normalizedVals.get(0));
+    }
+}

--- a/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/NationalProjectPostProcessorTest.java
+++ b/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/NationalProjectPostProcessorTest.java
@@ -11,8 +11,8 @@ public class NationalProjectPostProcessorTest extends ImporterTestcase {
     @Test
     public void testNationalProject() {
         NationalProjectPostProcessor processor = new NationalProjectPostProcessor();
-        assertEquals("CLARIN-NL", processor.process("Meertens TEST COLLECTION").get(0));
-        assertEquals("CLARIN-DK-UCPH", processor.process("CLARIN-DK-UCPH Repository").get(0));
-        assertEquals("CLARIN-D", processor.process("Universität des Saarlandes CLARIN-D-Zentrum, Saarbrücken").get(0));
+        assertEquals("CLARIN-NL", processor.process("Meertens TEST COLLECTION", null).get(0));
+        assertEquals("CLARIN-DK-UCPH", processor.process("CLARIN-DK-UCPH Repository", null).get(0));
+        assertEquals("CLARIN-D", processor.process("Universität des Saarlandes CLARIN-D-Zentrum, Saarbrücken", null).get(0));
     }
 }

--- a/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/OrganizationPostProcessorTest.java
+++ b/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/OrganizationPostProcessorTest.java
@@ -10,9 +10,9 @@ public class OrganizationPostProcessorTest extends ImporterTestcase {
     @Test
     public void testLanguageCode() {
         PostProcessor processor = new OrganisationPostProcessor();
-        assertEquals("Department of Psychology, Ohio State University", processor.process("http://buckeyecorpus.osu.edu").get(0));
-        assertEquals("s.n.", processor.process("s.n").get(0));
-        assertEquals("SELAF", processor.process("Société des Etudes Linguistiques et Anthropologiques de France").get(0));
-        assertEquals("NIAS", processor.process("Netherlands Institute of Advanced Study").get(0));
+        assertEquals("Department of Psychology, Ohio State University", processor.process("http://buckeyecorpus.osu.edu", null).get(0));
+        assertEquals("s.n.", processor.process("s.n", null).get(0));
+        assertEquals("SELAF", processor.process("Société des Etudes Linguistiques et Anthropologiques de France", null).get(0));
+        assertEquals("NIAS", processor.process("Netherlands Institute of Advanced Study", null).get(0));
     }
 }

--- a/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/TemporalCoveragePostProcessorTest.java
+++ b/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/TemporalCoveragePostProcessorTest.java
@@ -7,12 +7,12 @@ public class TemporalCoveragePostProcessorTest extends ImporterTestcase {
     @Test
     public void testNationalProject() {
         TemporalCoveragePostProcessor processor = new TemporalCoveragePostProcessor();
-        assertEquals("2012-12-01/", processor.process("2012-12-01/").get(0));
-        assertEquals("/2012", processor.process("/2012").get(0));
-        assertEquals("2012-02", processor.process("2012-02").get(0));
-        assertEquals("1997-07-16/1997-07-17", processor.process("1997-07-16/1997-07-17").get(0));
-        assertEquals("1994-11-05", processor.process("1994-11-05T08:15:30-05:00").get(0));
-        assertEquals(0, processor.process("northlimit=-16.4933; southlimit=-16.5617; westlimit=167.419; eastlimit=167.46").size());
-        assertEquals(0, processor.process("1. November").size());
+        assertEquals("2012-12-01/", processor.process("2012-12-01/", null).get(0));
+        assertEquals("/2012", processor.process("/2012", null).get(0));
+        assertEquals("2012-02", processor.process("2012-02", null).get(0));
+        assertEquals("1997-07-16/1997-07-17", processor.process("1997-07-16/1997-07-17", null).get(0));
+        assertEquals("1994-11-05", processor.process("1994-11-05T08:15:30-05:00", null).get(0));
+        assertEquals(0, processor.process("northlimit=-16.4933; southlimit=-16.5617; westlimit=167.419; eastlimit=167.46", null).size());
+        assertEquals(0, processor.process("1. November", null).size());
     }
 }

--- a/vlo-importer/src/test/resources/facetConceptsTest.xml
+++ b/vlo-importer/src/test/resources/facetConceptsTest.xml
@@ -376,7 +376,46 @@
 	<facetConcept name="availability" description="The usage conditions for the resource or tool" definition="A rough description of the conditions under which the resource or tool can be used.">
 		<concept>http://hdl.handle.net/11459/CCR_C-5303_9afa7d0c-f292-8e89-24f8-997a3d2971ae</concept>
 	</facetConcept>
+        
+        <facetConcept name="licenseType" description="Distribution and/or licence class (public, academic or restricted)" definition="A rights-based classification of language resources and tools, indicating the scope of the target audience">
+            <concept>http://hdl.handle.net/11459/CCR_C-5439_98bb103d-476a-7f62-54b4-bf9de24d2229</concept>
+        </facetConcept>
+        <facetConcept name="license" allowMultipleValues="true" description="The licensing conditions for the resource or tool" definition="The name of the license or a very brief description of the licensing conditions under which the resource or tool can be used.">
+		<!-- URL of the license -->
+		<concept>http://www.isocat.org/datcat/DC-6586</concept>
+		<concept>http://hdl.handle.net/11459/CCR_C-6586_2c79d86a-5a75-0890-d407-7d9cb86b9beb</concept>
+		
+		<!-- availability
+		Possibly with filtering:
+                A description of the licensing conditions. -->
+		<concept>http://www.isocat.org/datcat/DC-2453</concept>
+		<concept>http://hdl.handle.net/11459/CCR_C-2453_1f0c3ea5-7966-ae11-d3c6-448424d4e6e8</concept>
+                
+		<!-- license
+		Possibly with filtering:
+                A description of the licensing conditions under which the resource can be used. -->
+		<concept>http://www.isocat.org/datcat/DC-2457</concept>
+		<concept>http://hdl.handle.net/11459/CCR_C-2457_45bbaa1a-7002-2ecd-ab9d-57a189f694a6</concept>
+                
+                <!-- licence type
+		Possibly with filtering:
+                A description of the terms of availability of the resource in simple words. -->
+		<concept>http://www.isocat.org/datcat/DC-3800</concept>
+		<concept>http://hdl.handle.net/11459/CCR_C-3800_12a79edd-0ffe-8d82-9831-45d125c54aee</concept>
 
+		<!-- DASISH from DC Rights -->
+		<concept>http://www.isocat.org/datcat/DC-5439</concept>
+		<concept>http://hdl.handle.net/11459/CCR_C-5439_98bb103d-476a-7f62-54b4-bf9de24d2229</concept>
+
+                <!-- TEI header -->
+                <concept>http://hdl.handle.net/11459/CCR_C-5362_8cffd964-f57e-09ed-daed-eeabbf2d22c0</concept>
+                                		
+                <!-- the DC is used in the distributionType facet -->
+		<concept>http://purl.org/dc/terms/license</concept>
+		<concept>http://purl.org/dc/terms/rights</concept>
+		<concept>http://purl.org/dc/terms/accessRights</concept>
+		
+	</facetConcept>
 	<!-- test facets -->
 <!--	<facetConcept name="temporalCoverage" description="The temporal coverage of the source material of the resource" definition="The temporal coverage of the source material of the resource, i.e. not the time within which the resource was created, but when e.g. original texts were written or speech recordings made.">
 		<concept>http://www.isocat.org/datcat/DC-2502</concept>

--- a/vlo-solr/src/main/solr_conf/solr/collection1/conf/schema.xml
+++ b/vlo-solr/src/main/solr_conf/solr/collection1/conf/schema.xml
@@ -419,6 +419,7 @@
    <field name="country" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="languageCode" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="availability" type="string" indexed="true" stored="true" multiValued="true" default="UNSPECIFIED"/>
+   <field name="licenseType" type="string" indexed="true" stored="true" multiValued="true" default="UNSPECIFIED"/>
    <field name="license" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="accessInfo" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="organisation"  type="string" indexed="true" stored="true" multiValued="true"/>

--- a/vlo-solr/src/main/solr_conf/solr/collection1/conf/schema.xml
+++ b/vlo-solr/src/main/solr_conf/solr/collection1/conf/schema.xml
@@ -418,7 +418,7 @@
    <field name="continent" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="country" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="languageCode" type="string" indexed="true" stored="true" multiValued="true" />
-   <field name="availability" type="string" indexed="true" stored="true" multiValued="true" default="UNSPECIFIED"/>
+   <field name="availability" type="string" indexed="true" stored="true" multiValued="true"/>
    <field name="licenseType" type="string" indexed="true" stored="true" multiValued="true" default="UNSPECIFIED"/>
    <field name="license" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="accessInfo" type="string" indexed="true" stored="true" multiValued="true" />

--- a/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/config/VloSolrSpringConfig.java
+++ b/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/config/VloSolrSpringConfig.java
@@ -103,6 +103,7 @@ public class VloSolrSpringConfig {
             FacetConstants.FIELD_SUBJECT,
             FacetConstants.FIELD_ORGANISATION,
             FacetConstants.FIELD_LICENSE,
+            FacetConstants.FIELD_LICENSE_TYPE,
             FacetConstants.FIELD_AVAILABILITY,
             FacetConstants.FIELD_ACCESS_INFO,
             FacetConstants.FIELD_KEYWORDS,

--- a/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/service/solr/impl/SolrFacetFieldsService.java
+++ b/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/service/solr/impl/SolrFacetFieldsService.java
@@ -67,7 +67,7 @@ public class SolrFacetFieldsService implements FacetFieldsService {
         for (FacetField facet : response) {
             FacetSelection facetSelection = query.getSelectionValues(facet.getName());
 
-            if (facetSelection == null || facet.getName().equals(FacetConstants.FIELD_AVAILABILITY)) {
+            if (facetSelection == null || facet.getName().equals(FacetConstants.FIELD_LICENSE_TYPE)) {
                 filteredFacets.add(facet);
                 continue;
             } else {

--- a/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/model/CombinedLicenseTypeAvailabilityModel.java
+++ b/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/model/CombinedLicenseTypeAvailabilityModel.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2017 CLARIN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.clarin.cmdi.vlo.wicket.model;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import eu.clarin.cmdi.vlo.FacetConstants;
+import java.util.Collection;
+import java.util.Collections;
+import org.apache.wicket.model.AbstractReadOnlyModel;
+import org.apache.wicket.model.IModel;
+
+/**
+ * Model that combines information from the 'license type' and 'availability'
+ * fields, excluding the license type information from the latter to prevent
+ * an overlap or contradiction.
+ *
+ * Background information can be found in VLO issue #55 ({@link https://github.com/clarin-eric/VLO/issues/55})
+ * 
+ * @author twagoo
+ * @see FacetConstants#FIELD_AVAILABILITY
+ * @see FacetConstants#FIELD_LICENSE_TYPE
+ */
+public class CombinedLicenseTypeAvailabilityModel extends AbstractReadOnlyModel<Collection<String>> {
+
+    private final IModel<Collection<String>> licenseTypeModel;
+    private final IModel<Collection<String>> availabilityModel;
+
+    public CombinedLicenseTypeAvailabilityModel(IModel<Collection<String>> licenseTypeModel, IModel<Collection<String>> availabilityModel) {
+        this.licenseTypeModel = licenseTypeModel;
+        this.availabilityModel = availabilityModel;
+    }
+
+    @Override
+    public Collection<String> getObject() {
+        final Collection<String> availability = availabilityModel.getObject();
+        final Collection<String> licenseType = licenseTypeModel.getObject();
+        return ImmutableList.copyOf(
+                Iterables.concat(
+                        //license type
+                        (licenseType == null ? Collections.<String>emptyList() : licenseType),
+                        //availability properties with license types filtered out
+                        (availability == null ? Collections.<String>emptyList()
+                                : Iterables.filter(availability, new Predicate<String>() {
+                                    @Override
+                                    public boolean apply(String input) {
+                                        return !FacetConstants.LICENSE_TYPE_VALUES.contains(input);
+                                    }
+                                }))
+                )
+        );
+    }
+
+    @Override
+    public void detach() {
+        availabilityModel.detach();
+        licenseTypeModel.detach();
+    }
+
+}

--- a/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/pages/FacetedSearchPage.java
+++ b/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/pages/FacetedSearchPage.java
@@ -11,7 +11,6 @@ import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.panel.Panel;
-import org.apache.wicket.markup.repeater.data.IDataProvider;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
@@ -56,7 +55,7 @@ import org.apache.wicket.model.AbstractReadOnlyModel;
 public class FacetedSearchPage extends VloBasePage<QueryFacetsSelection> {
 
     private static final long serialVersionUID = 1L;
-    private final static List<String> ADDITIONAL_FACETS = ImmutableList.of(FacetConstants.FIELD_AVAILABILITY);
+    private final static List<String> ADDITIONAL_FACETS = ImmutableList.of(FacetConstants.FIELD_LICENSE_TYPE);
     public static final String TRACKING_EVENT_TITLE = "Search page";
 
     @SpringBean

--- a/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/panels/record/RecordLicenseInfoPanel.java
+++ b/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/panels/record/RecordLicenseInfoPanel.java
@@ -24,6 +24,7 @@ import eu.clarin.cmdi.vlo.config.VloConfig;
 import eu.clarin.cmdi.vlo.wicket.PreferredExplicitOrdering;
 import eu.clarin.cmdi.vlo.wicket.components.ToggleLink;
 import eu.clarin.cmdi.vlo.wicket.model.CollectionListModel;
+import eu.clarin.cmdi.vlo.wicket.model.CombinedLicenseTypeAvailabilityModel;
 import eu.clarin.cmdi.vlo.wicket.model.ConvertedFieldValueModel;
 import eu.clarin.cmdi.vlo.wicket.model.HandleLinkModel;
 import eu.clarin.cmdi.vlo.wicket.model.MapValueModel;
@@ -63,12 +64,14 @@ public class RecordLicenseInfoPanel extends GenericPanel<SolrDocument> {
     @SpringBean
     private VloConfig vloConfig;
 
+    private final IModel<Collection<String>> licenseTypeModel;
     private final IModel<Collection<String>> availabilityModel;
     private final IModel<Collection<String>> accessInfoModel;
     private final IModel<Collection<String>> licensesModel;
-    
+
     public RecordLicenseInfoPanel(String id, IModel<SolrDocument> model) {
         super(id, model);
+        this.licenseTypeModel = new SolrFieldModel<>(getModel(), FacetConstants.FIELD_LICENSE_TYPE);
         this.availabilityModel = new SolrFieldModel<>(getModel(), FacetConstants.FIELD_AVAILABILITY);
         this.accessInfoModel = new SolrFieldModel<>(getModel(), FacetConstants.FIELD_ACCESS_INFO);
         this.licensesModel = new SolrFieldModel<>(getModel(), FacetConstants.FIELD_LICENSE);
@@ -144,8 +147,8 @@ public class RecordLicenseInfoPanel extends GenericPanel<SolrDocument> {
         final Ordering<String> availabilityOrder = new PreferredExplicitOrdering(
                 //extract the 'primary' availability values from the configuration
                 FieldValueDescriptor.valuesList(vloConfig.getAvailabilityValues()));
-        
-        return new ListView<String>(id, new CollectionListModel<>(availabilityModel, availabilityOrder)) {
+
+        return new ListView<String>(id, new CollectionListModel<>(new CombinedLicenseTypeAvailabilityModel(licenseTypeModel, availabilityModel), availabilityOrder)) {
             @Override
             protected void populateItem(ListItem<String> item) {
 

--- a/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/panels/search/AvailabilityFacetPanel.java
+++ b/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/panels/search/AvailabilityFacetPanel.java
@@ -71,7 +71,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
  */
 public abstract class AvailabilityFacetPanel extends ExpandablePanel<QueryFacetsSelection> implements IAjaxIndicatorAware {
 
-    public static final String AVAILABILITY_FIELD = FacetConstants.FIELD_AVAILABILITY;
+    public static final String AVAILABILITY_FIELD = FacetConstants.FIELD_LICENSE_TYPE;
     private final List<String> availabilityLevels;
 
     @SpringBean
@@ -155,7 +155,7 @@ public abstract class AvailabilityFacetPanel extends ExpandablePanel<QueryFacets
                     //child label
                     .add(new FieldValueLabel("name", valueModel, fieldNameModel))
                     //count label
-                    .add(new Label("count", new PropertyModel<String>(item.getModel(), "count")))
+                    .add(new Label("count", new PropertyModel<>(item.getModel(), "count")))
                     //reference to checkbox
                     .add(new AttributeModifier("for", selector.getMarkupId()))
                     .add(new AttributeAppender("class", valueModel, " "))

--- a/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/panels/search/SearchResultItemLicensePanel.java
+++ b/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/panels/search/SearchResultItemLicensePanel.java
@@ -21,6 +21,7 @@ import eu.clarin.cmdi.vlo.FacetConstants;
 import eu.clarin.cmdi.vlo.pojo.SearchContext;
 import eu.clarin.cmdi.vlo.wicket.components.RecordPageLink;
 import eu.clarin.cmdi.vlo.wicket.model.CollectionListModel;
+import eu.clarin.cmdi.vlo.wicket.model.CombinedLicenseTypeAvailabilityModel;
 import eu.clarin.cmdi.vlo.wicket.model.ConvertedFieldValueModel;
 import eu.clarin.cmdi.vlo.wicket.model.FormattedStringModel;
 import eu.clarin.cmdi.vlo.wicket.model.SolrFieldModel;
@@ -50,8 +51,9 @@ public class SearchResultItemLicensePanel extends GenericPanel<SolrDocument> {
         this.searchContextModel = searchContextModel;
 
         //add 'tags' for all availability values
+        final SolrFieldModel<String> licenseTypeModel = new SolrFieldModel<>(getModel(), FacetConstants.FIELD_LICENSE_TYPE);
         final SolrFieldModel<String> availabilityModel = new SolrFieldModel<>(getModel(), FacetConstants.FIELD_AVAILABILITY);
-        add(new ListView<String>("availabilityTag", new CollectionListModel<>(availabilityModel, availabilityOrder)) {
+        add(new ListView<String>("availabilityTag", new CollectionListModel<>(new CombinedLicenseTypeAvailabilityModel(licenseTypeModel, availabilityModel), availabilityOrder)) {
             @Override
             protected void populateItem(ListItem<String> item) {
                 // add link to record

--- a/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/provider/FieldValueConverterProviderImpl.java
+++ b/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/provider/FieldValueConverterProviderImpl.java
@@ -61,6 +61,8 @@ public class FieldValueConverterProviderImpl implements FieldValueConverterProvi
                 return descriptionConverter;
             case FacetConstants.FIELD_AVAILABILITY:
                 return availabilityConverter;
+            case FacetConstants.FIELD_LICENSE_TYPE:
+                return availabilityConverter;
             case FacetConstants.FIELD_LICENSE:
                 return licenseConverter;
             default:

--- a/vlo-web-app/src/main/resources/fieldNames.properties
+++ b/vlo-web-app/src/main/resources/fieldNames.properties
@@ -31,6 +31,7 @@ field.dataProvider=Metadata source
 field.keywords=Keyword
 field.license=License
 field.accessInfo=Access information
+field.licenseType=License type
 
 #hidden/technical fields
 field.metadataSource=Metadata source

--- a/vlo-web-app/src/test/java/eu/clarin/cmdi/vlo/wicket/pages/TestFacetedSearchPage.java
+++ b/vlo-web-app/src/test/java/eu/clarin/cmdi/vlo/wicket/pages/TestFacetedSearchPage.java
@@ -71,11 +71,10 @@ public class TestFacetedSearchPage {
                         new FacetField("subject"),
                         new FacetField("format"),
                         new FacetField("organisation"),
-                        new FacetField("availability"),
+                        new FacetField("licenseType"),
                         new FacetField("nationalProject"),
                         new FacetField("keywords"),
-                        new FacetField("dataProvider"),
-                        new FacetField("licenseType")
+                        new FacetField("dataProvider")
                 )));
 
                 // mock search results

--- a/vlo-web-app/src/test/java/eu/clarin/cmdi/vlo/wicket/pages/TestFacetedSearchPage.java
+++ b/vlo-web-app/src/test/java/eu/clarin/cmdi/vlo/wicket/pages/TestFacetedSearchPage.java
@@ -74,7 +74,8 @@ public class TestFacetedSearchPage {
                         new FacetField("availability"),
                         new FacetField("nationalProject"),
                         new FacetField("keywords"),
-                        new FacetField("dataProvider")
+                        new FacetField("dataProvider"),
+                        new FacetField("licenseType")
                 )));
 
                 // mock search results


### PR DESCRIPTION
Fixes #39 and #55  with the introduction of a 'licenseType' field. Only the [licenseType](http://hdl.handle.net/11459/CCR_C-5439_98bb103d-476a-7f62-54b4-bf9de24d2229) concept is mapped. A new [license type map](https://github.com/clarin-eric/VLO-mapping/blob/vlo-issue39/uniform-maps/LicenseTypeMap.xml) in VLO-mapping maps a limited set of values to the PUB/ACA/RES vocabulary. If no value is mapped, the PUB/ACA/RES value from the availability field is copied to this field. Logic in the front end merges the two fields for combined display of license type and other availability properties.