### PR TITLE
find (conceptLink) context for attribute XPaths (issue #91)

### DIFF
--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/FacetMappingFactory.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/FacetMappingFactory.java
@@ -210,7 +210,13 @@ public class FacetMappingFactory {
         String context = null;
         String cpath = path.getPattern();
         while (context == null && !cpath.equals("/text()")) {
-            cpath = cpath.replaceAll("/[^/]*/text\\(\\)", "/text()");
+            if (cpath.contains("@")) {
+                // go to the parent element of the attribute
+                cpath = cpath.replaceAll("/@.*", "/text()");
+            } else {
+                // go to the parent element of the element
+                cpath = cpath.replaceAll("/[^/]*/text\\(\\)", "/text()");
+            }
             context = pathConceptLinkMapping.get(new Pattern(cpath));
         }
         return context;

--- a/vlo-importer/src/test/resources/facetConceptsTest.xml
+++ b/vlo-importer/src/test/resources/facetConceptsTest.xml
@@ -127,14 +127,15 @@
 		<concept>http://www.isocat.org/datcat/DC-5358</concept>
 		<concept>http://hdl.handle.net/11459/CCR_C-5358_3cd089fe-ad03-6181-b20c-635ea41ed818</concept>
 		<!--language (TEI) - MENZO: added for CLARIN-DK -->
+                <concept>http://purl.org/dc/terms/language</concept>
 
-    <concept>http://purl.org/dc/terms/language</concept>
-		<!-- Had to be removed due to IDSAGD_Speaker  <acceptableContext includeAny="false" includeEmpty="true"/>
-    <rejectableContext includeAny="true"  includeEmpty="false">
-      <concept>http://www.isocat.org/datcat/DC-4146</concept>
-      <concept>http://hdl.handle.net/11459/CCR_C-4146_5ccc45c8-d729-c180-2bf1-fccc56dde24d</concept>
-    </rejectableContext> -->
-		<pattern>/cmd:CMD/cmd:Components//cmdp:OLAC-DcmiTerms/cmdp:subject/@olac-language</pattern>
+                <acceptableContext includeAny="true" includeEmpty="true"/>
+                <rejectableContext includeAny="false"  includeEmpty="false">
+                    <concept>http://www.isocat.org/datcat/DC-4146</concept>
+                    <concept>http://hdl.handle.net/11459/CCR_C-4146_5ccc45c8-d729-c180-2bf1-fccc56dde24d</concept>
+                </rejectableContext>
+
+                <pattern>/cmd:CMD/cmd:Components//cmdp:OLAC-DcmiTerms/cmdp:subject/@olac-language</pattern>
 		<pattern>/cmd:CMD/cmd:Components/cmdp:LrtInventoryResource/cmdp:LrtCommon/cmdp:Languages/cmdp:ISO639/cmdp:iso-639-3-code/text()</pattern>
 		<pattern>/cmd:CMD/cmd:Components/cmdp:mods/cmdp:language/cmdp:languageTerm/text()</pattern>
 


### PR DESCRIPTION
Fixes for issue #91:
- ``FacetMappingFactory.getContext()``: recognize paths to attributes and jump to its parent element
- ``facetConceptsTest.xml``: enable context white/blacklist, so ``getContext()`` gets triggered