### PR TITLE
Remove reference to the Max Planck's Nexus instance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,6 @@
                 <enabled>false</enabled>
             </releases>
         </repository>
-        <!-- TODO: get rid of dependency on MPI repository -->
-        <repository>
-            <id>MPI</id>
-            <name>MPI LAT Repository</name>
-            <url>http://lux15.mpi.nl/nexus/content/groups/public</url>
-        </repository>
     </repositories>
     	
 </project>

--- a/vlo-web-app/pom.xml
+++ b/vlo-web-app/pom.xml
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>nl.mpi.corpusstructure</groupId>
             <artifactId>corpus-structure-2-core</artifactId>
-            <version>1.1.7</version>
+            <version>1.2.4</version>
         </dependency>
         <dependency>
             <groupId>de.agilecoders.wicket</groupId>


### PR DESCRIPTION
Some artifacts have now been copied over to the CLARIN Nexus. POMs adapted in this pull request.