### PR TITLE
Extract the main constructions of curation dashboard

### DIFF
--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/AnalysisRecordProcessor.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/AnalysisRecordProcessor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 CLARIN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.clarin.cmdi.vlo.importer.api;
+
+import eu.clarin.cmdi.vlo.config.FieldNameService;
+import eu.clarin.cmdi.vlo.importer.CMDIRecordProcessor;
+import eu.clarin.cmdi.vlo.importer.processor.CMDIDataProcessor;
+import eu.clarin.cmdi.vlo.importer.processor.ValueSet;
+import java.util.List;
+import java.util.Map;
+
+class AnalysisRecordProcessor extends CMDIRecordProcessor<Map<String, List<ValueSet>>> {
+
+    AnalysisRecordProcessor(CMDIDataProcessor<Map<String, List<ValueSet>>> dataProcessor,
+            FieldNameService fieldNameService) {
+        super(dataProcessor, fieldNameService);
+    }
+
+    @Override
+    protected boolean skipOnDuplicateId() {
+        return false;
+    }
+
+    @Override
+    protected boolean skipOnNoResources() {
+        return false;
+    }
+}

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/CmdiRecordAnalyzer.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/CmdiRecordAnalyzer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 CLARIN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.clarin.cmdi.vlo.importer.api;
+
+import eu.clarin.cmdi.vlo.LanguageCodeUtils;
+import eu.clarin.cmdi.vlo.config.FieldNameService;
+import eu.clarin.cmdi.vlo.config.FieldNameServiceImpl;
+import eu.clarin.cmdi.vlo.config.VloConfig;
+import eu.clarin.cmdi.vlo.importer.CMDIData;
+import eu.clarin.cmdi.vlo.importer.CMDIDataFactory;
+import eu.clarin.cmdi.vlo.importer.CMDIRecordProcessor;
+import eu.clarin.cmdi.vlo.importer.MetadataImporter;
+import eu.clarin.cmdi.vlo.importer.VLOMarshaller;
+import eu.clarin.cmdi.vlo.importer.processor.CMDIDataProcessor;
+import eu.clarin.cmdi.vlo.importer.processor.CMDIParserVTDXML;
+import eu.clarin.cmdi.vlo.importer.processor.ValueSet;
+import eu.clarin.cmdi.vlo.importer.solr.DocumentStoreException;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Analyses a single CMDI file: applies VLO's facet mapping and returns the
+ * resulting record, without importing anything.
+ */
+@FunctionalInterface
+public interface CmdiRecordAnalyzer {
+
+    /**
+     * Analyses one CMDI file.
+     *
+     * @param file the CMDI record
+     * @return the analysed record, or empty if the processor skipped the file
+     * @throws DocumentStoreException if the record could not be turned into a
+     * document
+     * @throws IOException if the file could not be read
+     */
+    Optional<CMDIData<Map<String, List<ValueSet>>>> analyze(File file)
+            throws DocumentStoreException, IOException;
+
+    /**
+     * Creates an analyzer.
+     *
+     * <p>
+     * The provider is the only setting. Everything else is fixed for analysis
+     * rather than import: no record is skipped, and values are kept as full
+     * {@link ValueSet}s.
+     * </p>
+     *
+     * @param vloConfig VLO configuration; supplies facet concepts, facets
+     * configuration and profile schema resolution
+     * @param facetsMappingProvider resolves a profile schema location to the
+     * mapping to apply, and is the natural place to cache
+     * @return a new analyzer
+     * @throws NullPointerException if either argument is {@code null}
+     */
+    static CmdiRecordAnalyzer create(VloConfig vloConfig, FacetsMappingProvider facetsMappingProvider) {
+        Objects.requireNonNull(vloConfig, "vloConfig");
+        Objects.requireNonNull(facetsMappingProvider, "facetsMappingProvider");
+
+        final FieldNameService fieldNames = new FieldNameServiceImpl(vloConfig);
+        final CMDIDataFactory<Map<String, List<ValueSet>>> dataFactory
+                = new ValueSetCmdiData.Factory(fieldNames);
+        final VLOMarshaller vloMarshaller = new VLOMarshaller();
+
+        final CMDIDataProcessor<Map<String, List<ValueSet>>> dataProcessor = new CMDIParserVTDXML<>(
+                MetadataImporter.registerPostProcessors(vloConfig, fieldNames, new LanguageCodeUtils(vloConfig)),
+                MetadataImporter.registerPostMappingFilters(fieldNames),
+                vloConfig,
+                new ProviderBackedMappingFactory(vloConfig, vloMarshaller, facetsMappingProvider),
+                vloMarshaller,
+                dataFactory,
+                fieldNames,
+                false);
+
+        final CMDIRecordProcessor<Map<String, List<ValueSet>>> processor
+                = new AnalysisRecordProcessor(dataProcessor, fieldNames);
+
+        return processor::processRecord;
+    }
+}

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/FacetsMappingBuilder.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/FacetsMappingBuilder.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 CLARIN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.clarin.cmdi.vlo.importer.api;
+
+import eu.clarin.cmdi.vlo.config.VloConfig;
+import eu.clarin.cmdi.vlo.importer.Pattern;
+import eu.clarin.cmdi.vlo.importer.VLOMarshaller;
+import eu.clarin.cmdi.vlo.importer.mapping.ConceptLinkPathMapper;
+import eu.clarin.cmdi.vlo.importer.mapping.FacetMappingFactory;
+import eu.clarin.cmdi.vlo.importer.mapping.FacetsMapping;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Builds a {@link FacetsMapping} for a profile from caller-supplied concept
+ * links.
+ *
+ * <p>
+ * This is the supported way to apply VLO's facet-concept configuration to
+ * concept links you resolved yourself.
+ * </p>
+ * <p>
+ * Construction parses {@code facetConcepts.xml} and the facets configuration, so
+ * build one instance and keep it. The builder holds no per-profile state and
+ * does no caching — see {@link FacetsMappingProvider} for that.
+ * </p>
+ */
+public class FacetsMappingBuilder {
+
+    private final MappingFactory factory;
+
+    /**
+     * @param vloConfig VLO configuration supplying the facet concepts and facets
+     * configuration files
+     */
+    public FacetsMappingBuilder(VloConfig vloConfig) {
+        this(vloConfig, new VLOMarshaller());
+    }
+
+    /**
+     * Exists for tests that need to supply their own marshaller. Embedders use
+     * {@link #FacetsMappingBuilder(VloConfig)}.
+     *
+     * @param vloConfig VLO configuration supplying the facet concepts and facets
+     * configuration files
+     * @param marshaller marshaller used to read those files
+     */
+    FacetsMappingBuilder(VloConfig vloConfig, VLOMarshaller marshaller) {
+        this.factory = new MappingFactory(
+                Objects.requireNonNull(vloConfig, "vloConfig"),
+                Objects.requireNonNull(marshaller, "marshaller"));
+    }
+
+    /**
+     * Builds the mapping for one profile.
+     *
+     * @param schemaLocation URL of the CMDI profile schema
+     * @param conceptLinkPaths concept URI to the XPath patterns
+     * @return a new mapping; callers that want caching should hold the result
+     * behind a {@link FacetsMappingProvider}
+     */
+    public FacetsMapping build(String schemaLocation, Map<String, List<Pattern>> conceptLinkPaths) {
+        Objects.requireNonNull(schemaLocation, "schemaLocation");
+        Objects.requireNonNull(conceptLinkPaths, "conceptLinkPaths");
+        return factory.build(schemaLocation, conceptLinkPaths);
+    }
+
+    /**
+     * The one place that still touches {@code protected createMapping}. Private
+     * to have it as an implementation detail of this class, not a surface
+     * embedders extend.
+     */
+    private static final class MappingFactory extends FacetMappingFactory {
+
+        MappingFactory(VloConfig vloConfig, VLOMarshaller marshaller) {
+            super(vloConfig, marshaller);
+        }
+
+        FacetsMapping build(String schemaLocation, Map<String, List<Pattern>> conceptLinkPaths) {
+            return createMapping(new ConceptLinkPathMapper() {
+
+                @Override
+                public Map<String, List<Pattern>> createConceptLinkPathMapping() {
+                    return conceptLinkPaths;
+                }
+
+                @Override
+                public String getXsd() {
+                    return schemaLocation;
+                }
+
+                @Override
+                public Boolean useLocalXSDCache() {
+                    // irrelevant: the caller resolved the concept links already,
+                    // so no XSD is fetched on this path
+                    return true;
+                }
+            });
+        }
+    }
+}

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/FacetsMappingDecorator.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/FacetsMappingDecorator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 CLARIN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.clarin.cmdi.vlo.importer.api;
+
+import eu.clarin.cmdi.vlo.importer.mapping.FacetDefinition;
+import eu.clarin.cmdi.vlo.importer.mapping.FacetsMapping;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A {@link FacetsMapping} that adds extra facet definitions on top of another
+ * mapping.
+ *
+ */
+public class FacetsMappingDecorator extends FacetsMapping {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private final FacetsMapping delegate;
+    private final LinkedHashMap<String, FacetDefinition> additional;
+
+    /**
+     * @param delegate the mapping to extend
+     * @param additionalFacets extra definitions, keyed by facet name; iteration
+     * order is preserved
+     */
+    public FacetsMappingDecorator(FacetsMapping delegate, Map<String, FacetDefinition> additionalFacets) {
+        super(Objects.requireNonNull(delegate, "delegate").getFacetsConfigurations());
+        this.delegate = delegate;
+        this.additional = new LinkedHashMap<>(Objects.requireNonNull(additionalFacets, "additionalFacets"));
+    }
+
+    @Override
+    public Collection<FacetDefinition> getFacetDefinitions() {
+        final Collection<FacetDefinition> union = new ArrayList<>(delegate.getFacetDefinitions());
+        union.addAll(additional.values());
+        return union;
+    }
+
+    @Override
+    public Collection<String> getFacetConfigurationNames() {
+        final Collection<String> union = new ArrayList<>(delegate.getFacetConfigurationNames());
+        union.addAll(additional.keySet());
+        return union;
+    }
+
+    @Override
+    public FacetDefinition getFacetDefinition(String facetName) {
+        final FacetDefinition extra = additional.get(facetName);
+        return extra != null ? extra : delegate.getFacetDefinition(facetName);
+    }
+
+    @Override
+    public String toString() {
+        return "FacetsMappingDecorator{additional=" + additional.keySet() + ", delegate=" + delegate + '}';
+    }
+}

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/FacetsMappingProvider.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/FacetsMappingProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 CLARIN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.clarin.cmdi.vlo.importer.api;
+
+import eu.clarin.cmdi.vlo.importer.mapping.FacetsMapping;
+
+/**
+ * Resolves a CMDI profile schema location to the facet mapping to apply.
+ *
+ * @see CmdiRecordAnalyzer
+ */
+@FunctionalInterface
+public interface FacetsMappingProvider {
+
+    /**
+     * @param schemaLocation URL of the CMDI profile schema
+     * @return the mapping to apply; never {@code null}
+     */
+    FacetsMapping getFacetsMapping(String schemaLocation);
+}

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/ProviderBackedMappingFactory.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/ProviderBackedMappingFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 CLARIN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.clarin.cmdi.vlo.importer.api;
+
+import eu.clarin.cmdi.vlo.config.VloConfig;
+import eu.clarin.cmdi.vlo.importer.VLOMarshaller;
+import eu.clarin.cmdi.vlo.importer.mapping.FacetMappingFactory;
+import eu.clarin.cmdi.vlo.importer.mapping.FacetsMapping;
+
+/**
+ * Routes the parser's profile-id lookups to the configured
+ * {@link FacetsMappingProvider}, resolving the profile id to a schema location
+ * first.
+ * </p>
+ */
+class ProviderBackedMappingFactory extends FacetMappingFactory {
+
+    private final VloConfig vloConfig;
+    private final FacetsMappingProvider provider;
+
+    ProviderBackedMappingFactory(VloConfig vloConfig, VLOMarshaller marshaller, FacetsMappingProvider provider) {
+        super(vloConfig, marshaller);
+        this.vloConfig = vloConfig;
+        this.provider = provider;
+    }
+
+    @Override
+    public FacetsMapping getFacetMapping(String profileId, Boolean useLocalXSDCache) {
+        return provider.getFacetsMapping(vloConfig.getComponentRegistryProfileSchema(profileId));
+    }
+}

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/ValueSetCmdiData.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/ValueSetCmdiData.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 CLARIN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.clarin.cmdi.vlo.importer.api;
+
+import eu.clarin.cmdi.vlo.FieldKey;
+import eu.clarin.cmdi.vlo.config.FieldNameService;
+import eu.clarin.cmdi.vlo.importer.CMDIData;
+import eu.clarin.cmdi.vlo.importer.CMDIDataBaseImpl;
+import eu.clarin.cmdi.vlo.importer.CMDIDataFactory;
+import eu.clarin.cmdi.vlo.importer.mapping.FacetDefinition;
+import eu.clarin.cmdi.vlo.importer.mapping.TargetFacet;
+import eu.clarin.cmdi.vlo.importer.processor.LanguageDefaults;
+import eu.clarin.cmdi.vlo.importer.processor.ValueSet;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * A {@link CMDIData} implementation that retains the full {@link ValueSet} for
+ * every facet value.
+ *
+ * <p>
+ * VLO's import path keeps only the value, because that is all Solr needs. Curation
+ * needs more info like: which VTD index in the source document a value came
+ * from, whether it was derived from another facet, and whether it is
+ * the result of a value mapping. This implementation keeps all of it, so
+ * embedders no longer have to write their own subclass of
+ * {@link CMDIDataBaseImpl} to get at it.
+ * </p>
+ */
+public class ValueSetCmdiData extends CMDIDataBaseImpl<Map<String, List<ValueSet>>> {
+
+    /**
+     * Origin facet name recorded for values added by facet name rather than by
+     * {@link ValueSet}, where the true origin is not known.
+     */
+    static final String UNKNOWN_ORIGIN_FACET = "unknown";
+
+    /**
+     * VTD index for a value that has no position in the source document.
+     */
+    private static final int NO_VTD_INDEX = -1;
+
+    private final Map<String, List<ValueSet>> facetValuesMap = new HashMap<>();
+
+    public ValueSetCmdiData(FieldNameService fieldNameService) {
+        super(fieldNameService);
+    }
+
+    @Override
+    public void addDocField(ValueSet valueSet, boolean caseInsensitive) {
+        final String facetName = valueSet.getTargetFacetName();
+        if (fieldNameService.getFieldName(FieldKey.ID).equals(facetName)) {
+            setId(valueSet.getValue().trim());
+        } else {
+            addValueSet(valueSet, caseInsensitive);
+        }
+    }
+
+    @Override
+    public void addDocField(String facetName, Object value, boolean caseInsensitive) {
+        addValueSet(facetName, value, caseInsensitive);
+    }
+
+    @Override
+    public void addDocFieldIfNull(ValueSet valueSet, boolean caseInsensitive) {
+        if (this.facetValuesMap.containsKey(valueSet.getTargetFacetName())) {
+            addDocField(valueSet, caseInsensitive);
+        }
+    }
+
+    @Override
+    public Collection<Object> getDocField(String facetName) {
+        final List<ValueSet> valueSets = this.facetValuesMap.get(facetName);
+        return valueSets == null
+                ? null
+                : valueSets.stream().map(ValueSet::getValue).collect(Collectors.toList());
+    }
+
+    @Override
+    public Map<String, List<ValueSet>> getDocument() {
+        return this.facetValuesMap;
+    }
+
+    @Override
+    public void replaceDocField(ValueSet valueSet, boolean caseInsensitive) {
+        removeField(valueSet.getTargetFacetName());
+        addDocFieldIfNull(valueSet, caseInsensitive);
+    }
+
+    @Override
+    public void replaceDocField(String facetName, Object value, boolean caseInsensitive) {
+        removeField(facetName);
+        addValueSet(facetName, value, caseInsensitive);
+    }
+
+    @Override
+    public void removeField(String facetName) {
+        this.facetValuesMap.remove(facetName);
+    }
+
+    @Override
+    public boolean hasField(String facetName) {
+        return this.facetValuesMap.containsKey(facetName);
+    }
+
+    @Override
+    public Collection<Object> getFieldValues(String facetName) {
+        return getDocField(facetName);
+    }
+
+    private void addValueSet(ValueSet valueSet, boolean caseInsensitive) {
+        if (caseInsensitive) {
+            valueSet.setValue(valueSet.getValueLanguagePair().getLeft().trim().toLowerCase());
+        }
+        this.facetValuesMap
+                .computeIfAbsent(valueSet.getTargetFacetName(), name -> new ArrayList<>())
+                .add(valueSet);
+    }
+
+    private void addValueSet(String facetName, Object value, boolean caseInsensitive) {
+        // create a synthetic ValueSet
+        if (value == null) {
+            return;
+        }
+        final String stringValue = value.toString();
+        final FacetDefinition noOrigin = new FacetDefinition(null, UNKNOWN_ORIGIN_FACET);
+        final TargetFacet target = new TargetFacet(new FacetDefinition(null, facetName), stringValue);
+
+        addValueSet(
+                new ValueSet(NO_VTD_INDEX, noOrigin, target,
+                        Pair.of(stringValue, LanguageDefaults.DEFAULT_LANGUAGE),
+                        false, false),
+                caseInsensitive);
+    }
+
+    public static class Factory implements CMDIDataFactory<Map<String, List<ValueSet>>> {
+
+        private final FieldNameService fieldNameService;
+
+        public Factory(FieldNameService fieldNameService) {
+            this.fieldNameService = fieldNameService;
+        }
+
+        @Override
+        public CMDIData<Map<String, List<ValueSet>>> newCMDIDataInstance() {
+            return new ValueSetCmdiData(this.fieldNameService);
+        }
+    }
+}

--- a/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/package-info.java
+++ b/vlo-importer/src/main/java/eu/clarin/cmdi/vlo/importer/api/package-info.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 CLARIN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/**
+ * Stable API for embedding VLO's CMDI analysis in another application.
+ *
+ * <p>
+ * This package exists for consumers that want to run a CMDI record through
+ * VLO's facet mapping and inspect the result, without running a VLO import. The
+ * CLARIN curation dashboard is the motivating consumer, but nothing here is
+ * curation-specific.
+ * </p>
+ *
+ * <h2>Typical use</h2>
+ * <pre>{@code
+ * // 1. apply VLO's facet config to concept links you resolved yourself
+ * FacetsMappingBuilder builder = new FacetsMappingBuilder(vloConfig);
+ * Map<String, List<Pattern>> conceptLinkPaths = myProfileParser.conceptLinkPaths(schemaLocation);
+ * FacetsMapping mapping = builder.build(schemaLocation, conceptLinkPaths);
+ *
+ * // 2. optionally add facets that are not in facetConcepts.xml
+ * mapping = new FacetsMappingDecorator(mapping, myExtraDefinitions);
+ *
+ * // 3. analyse records, caching mappings however you like
+ * CmdiRecordAnalyzer analyzer = CmdiRecordAnalyzer.create(vloConfig, myCachingProvider);
+ *
+ * Optional<CMDIData<Map<String, List<ValueSet>>>> record = analyzer.analyze(file);
+ * }</pre>
+ *
+ * <h2>Document type</h2>
+ * <p>
+ * The analyzer produces records whose document is
+ * {@code Map<String, List<ValueSet>>}: every facet keeps its full
+ * {@link eu.clarin.cmdi.vlo.importer.processor.ValueSet} rather than just the
+ * string value, so the embedder can still see the VTD index a value came from
+ * and whether it was derived or produced by a value mapping. VLO's own importer
+ * discards that; an analysis tool generally needs it.
+ * </p>
+ *
+ * <h2>Compatibility</h2>
+ * <p>
+ * Treat the public types in this package as a published contract: additive
+ * changes are fine, but changing an existing signature breaks embedders.
+ * {@code CmdiRecordAnalyzerContractTest} in the test sources pins the surface;
+ * if it stops compiling, the change is breaking.
+ * </p>
+ */
+package eu.clarin.cmdi.vlo.importer.api;

--- a/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/api/CmdiRecordAnalyzerContractTest.java
+++ b/vlo-importer/src/test/java/eu/clarin/cmdi/vlo/importer/api/CmdiRecordAnalyzerContractTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2026 CLARIN
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package eu.clarin.cmdi.vlo.importer.api;
+
+import eu.clarin.cmdi.vlo.importer.CMDIData;
+import eu.clarin.cmdi.vlo.importer.ImporterTestcase;
+import eu.clarin.cmdi.vlo.importer.Pattern;
+import eu.clarin.cmdi.vlo.importer.Resource;
+import eu.clarin.cmdi.vlo.importer.mapping.FacetDefinition;
+import eu.clarin.cmdi.vlo.importer.mapping.FacetsMapping;
+import eu.clarin.cmdi.vlo.importer.processor.ValueSet;
+import java.io.File;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Contract test for {@link eu.clarin.cmdi.vlo.importer.api}.
+ *
+ * <p>
+ * This test is the guard on the published embedding API. It exercises the whole
+ * path an embedder uses — supply your own concept links, decorate the mapping
+ * with facets VLO does not define, cache mappings yourself, analyze a record and
+ * read per-value provenance back out — so a change that breaks embedders fails
+ * here rather than downstream.
+ * </p>
+ */
+public class CmdiRecordAnalyzerContractTest extends ImporterTestcase {
+
+    private static final String PROFILE_ID = "clarin.eu:cr1:p_1274880881885";
+
+    private FacetsMappingBuilder mappingBuilder;
+
+    @BeforeEach
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        config.setFacetConceptsFile(getTestFacetConceptFilePath());
+        config.setFacetsConfigFile(
+                new File(Objects.requireNonNull(getClass().getResource("/facetConfigTest.xml")).toURI()).getAbsolutePath());
+        mappingBuilder = new FacetsMappingBuilder(config, marshaller);
+    }
+
+    /**
+     * The motivating end-to-end case: an embedder that resolves concept links
+     * itself, adds facets VLO does not define, and needs per-value provenance.
+     */
+    @Test
+    public void analysesRecordWithCallerSuppliedMappingAndExtraFacets() throws Exception {
+        final FacetsMappingProvider provider = schemaLocation
+                -> new FacetsMappingDecorator(
+                        mappingBuilder.build(schemaLocation, emptyConceptLinks()),
+                        extraFacets());
+
+        final CmdiRecordAnalyzer analyzer = CmdiRecordAnalyzer.create(config, provider);
+
+        final Optional<CMDIData<Map<String, List<ValueSet>>>> result = analyzer.analyze(corpusRecord());
+
+        assertTrue(result.isPresent(), "record should not have been skipped");
+        final CMDIData<Map<String, List<ValueSet>>> data = result.get();
+
+        // the record was really parsed, not just constructed
+        assertEquals("test-hdl_58_1839_47_00-0000-0000-0000-0001-D", data.getId());
+        final List<Resource> metadataResources = data.getMetadataResources();
+        assertEquals(3, metadataResources.size());
+        assertEquals("../acqui_data/Corpusstructure/acqui.imdi.cmdi",
+                metadataResources.getFirst().getResourceName());
+
+        // the decorated facet, which exists only because the embedder added it,
+        // captured a value that VLO itself never stores
+        final Map<String, List<ValueSet>> document = data.getDocument();
+        final List<ValueSet> mdProfile = document.get("test_mdProfile");
+        assertNotNull(mdProfile, "decorated facet should have been applied; facets present: " + document.keySet());
+        assertEquals(PROFILE_ID, mdProfile.getFirst().getValue());
+
+        // provenance is retained, which is the reason for ValueSetCmdiData
+        final ValueSet valueSet = mdProfile.getFirst();
+        assertEquals("test_mdProfile", valueSet.getTargetFacetName());
+        assertFalse(valueSet.isDerived());
+        assertFalse(valueSet.isResultOfValueMapping());
+        assertNotNull(valueSet.getValueLanguagePair());
+        assertTrue(valueSet.getVtdIndex() >= 0, "value should carry its source position");
+    }
+
+    /**
+     * The provider is the embedder's caching seam: the analyzer must go through
+     * it for every record, and must resolve the profile id to a schema location
+     * before doing so.
+     */
+    @Test
+    public void routesEveryRecordThroughTheMappingProvider() throws Exception {
+        final Map<String, FacetsMapping> cache = new ConcurrentHashMap<>();
+        final AtomicInteger lookups = new AtomicInteger();
+
+        final FacetsMappingProvider caching = schemaLocation -> {
+            lookups.incrementAndGet();
+            return cache.computeIfAbsent(schemaLocation,
+                    location -> mappingBuilder.build(location, emptyConceptLinks()));
+        };
+
+        final CmdiRecordAnalyzer analyzer = CmdiRecordAnalyzer.create(config, caching);
+
+        analyzer.analyze(corpusRecord());
+        analyzer.analyze(corpusRecord());
+
+        assertEquals(2, lookups.get(), "provider should be consulted per record");
+        assertEquals(1, cache.size(), "both records resolve to the same profile");
+
+        // the provider receives a resolved schema location, not the raw profile id
+        final String schemaLocation = cache.keySet().iterator().next();
+        assertEquals(config.getComponentRegistryProfileSchema(PROFILE_ID), schemaLocation);
+    }
+
+    /**
+     * The decorator must not disturb the mapping it wraps.
+     */
+    @Test
+    public void decoratorAddsFacetsWithoutMutatingTheDelegate() {
+        final FacetsMapping delegate = mappingBuilder.build(
+                config.getComponentRegistryProfileSchema(PROFILE_ID), emptyConceptLinks());
+        final int facetsBefore = delegate.getFacetDefinitions().size();
+
+        final FacetsMapping decorated = new FacetsMappingDecorator(delegate, extraFacets());
+
+        assertEquals(facetsBefore + 1, decorated.getFacetDefinitions().size());
+        assertEquals(facetsBefore, delegate.getFacetDefinitions().size(), "delegate must be untouched");
+        assertTrue(decorated.getFacetConfigurationNames().contains("test_mdProfile"));
+        assertFalse(delegate.getFacetConfigurationNames().contains("test_mdProfile"));
+
+        // added definitions resolve, delegate definitions still resolve through
+        assertEquals("test_mdProfile", decorated.getFacetDefinition("test_mdProfile").getName());
+        assertSame(delegate.getFacetsConfigurations(), decorated.getFacetsConfigurations());
+    }
+
+    /**
+     * A missing mapping provider is the one misconfiguration worth failing loudly
+     * on, since everything else has a usable default.
+     */
+    @Test
+    public void requiresAMappingProvider() {
+        assertThrows(NullPointerException.class,
+                () -> CmdiRecordAnalyzer.create(config, null));
+    }
+
+    /**
+     * Values added by facet name rather than by {@link ValueSet} still arrive as
+     * ValueSets, so consumers never have to special-case them.
+     */
+    @Test
+    public void synthesisesValueSetsForValuesAddedByName() {
+        final ValueSetCmdiData data = new ValueSetCmdiData(fieldNameService);
+
+        data.addDocField("some_facet", "some value", false);
+
+        final List<ValueSet> values = data.getDocument().get("some_facet");
+        assertEquals(1, values.size());
+        assertEquals("some value", values.get(0).getValue());
+        assertEquals(-1, values.get(0).getVtdIndex(), "no source position for synthesised values");
+        assertEquals(List.of("some value"), List.copyOf(data.getDocField("some_facet")));
+        assertTrue(data.hasField("some_facet"));
+
+        data.removeField("some_facet");
+        assertFalse(data.hasField("some_facet"));
+        assertNull(data.getDocField("some_facet"), "absent facet reads as null, not empty");
+    }
+
+    private Map<String, List<Pattern>> emptyConceptLinks() {
+        // an embedder that finds no concept links still gets a usable mapping:
+        // the fallback patterns from facetConcepts.xml apply
+        return Map.of();
+    }
+
+    private Map<String, FacetDefinition> extraFacets() {
+        final FacetDefinition mdProfile = new FacetDefinition(null, "test_mdProfile");
+        mdProfile.setPattern(new Pattern("/cmd:CMD/cmd:Header/cmd:MdProfile/text()"));
+
+        final LinkedHashMap<String, FacetDefinition> extra = new LinkedHashMap<>();
+        extra.put("test_mdProfile", mdProfile);
+        return extra;
+    }
+
+    private File corpusRecord() throws Exception {
+        final String content = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <CMD xmlns="http://www.clarin.eu/cmd/1" xmlns:cmdp="http://www.clarin.eu/cmd/1/profiles/clarin.eu:cr1:p_1274880881885" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                   <Header>
+                      <MdCreationDate>2003-01-14</MdCreationDate>
+                      <MdSelfLink>test-hdl:1839/00-0000-0000-0000-0001-D</MdSelfLink>
+                      <MdProfile>clarin.eu:cr1:p_1274880881885</MdProfile>
+                   </Header>
+                   <Resources>
+                      <ResourceProxyList>
+                         <ResourceProxy id="d28635e19">
+                            <ResourceType>Metadata</ResourceType>
+                            <ResourceRef>../acqui_data/Corpusstructure/acqui.imdi.cmdi</ResourceRef>
+                         </ResourceProxy>
+                         <ResourceProxy id="d28635e23">
+                            <ResourceType>Metadata</ResourceType>
+                            <ResourceRef>../Comprehension/Corpusstructure/comprehension.imdi.cmdi</ResourceRef>
+                         </ResourceProxy>
+                         <ResourceProxy id="d28635e26">
+                            <ResourceType>Metadata</ResourceType>
+                            <ResourceRef>../lac_data/Corpusstructure/lac.imdi.cmdi</ResourceRef>
+                         </ResourceProxy>
+                      </ResourceProxyList>
+                      <JournalFileProxyList/>
+                      <ResourceRelationList/>
+                   </Resources>
+                   <Components>
+                      <cmdp:imdi-corpus>
+                         <cmdp:Corpus>
+                            <cmdp:Name>MPI corpora</cmdp:Name>
+                            <cmdp:Title>Corpora of the Max-Planck Institute for Psycholinguistics</cmdp:Title>
+                            <cmdp:descriptions>
+                               <cmdp:Description LanguageId="">IMDI corpora</cmdp:Description>
+                            </cmdp:descriptions>
+                         </cmdp:Corpus>
+                      </cmdp:imdi-corpus>
+                   </Components>
+                </CMD>
+                """;
+        return createCmdiFile("contractCorpus", content);
+    }
+}


### PR DESCRIPTION
Extract the main constructions of curation dashboard to create a contract and a more stable dependency style.

This is in connection with the changes of the [curation fork branch](https://github.com/radudoros/curation-dashboard/compare/main...radudoros:curation-dashboard:vlo-api-migration)

Main idea is to have a stable interface exposed by the vlo and have the curation dashboard repo not worry about the implemnetation and just consume the exposed contract extension classes.