### PR TITLE
Fix in to show replacement in Bootstrap 5

### DIFF
--- a/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/panels/search/DuplicateSearchResultItemsPanel.html
+++ b/vlo-web-app/src/main/java/eu/clarin/cmdi/vlo/wicket/panels/search/DuplicateSearchResultItemsPanel.html
@@ -32,7 +32,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         </span>
                     </a>
                 </div>
-                <div wicket:id="duplicatesView" class="search-results-duplicates-list collapse in">
+                <div wicket:id="duplicatesView" class="search-results-duplicates-list collapse show">
                     <p class="duplicates-list-explanation"><span class="fa fa-info-circle"></span> <wicket:message key="duplicateresults.alsoMatch">[The following record(s) also match your query and/or facet selection but have been grouped together to reduce the number of similar looking search results:]</wicket:message></p>
                     <div class="list-group">
                         <wicket:container wicket:id="duplicateItem">

--- a/vlo-web-app/src/main/scss/inc/_vlo-search.scss
+++ b/vlo-web-app/src/main/scss/inc/_vlo-search.scss
@@ -262,6 +262,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
     .search-results-duplicates {
         clear: both;
         margin-top: .5em;
+        background-color: clarin-theme.$panel-default-heading-bg;
 
         .search-results-duplicates-heading {
             a.search-results-duplicates-expand-collapse {


### PR DESCRIPTION
Bootstrap 4 removed .in and replaced it with .show. This fixes the duplicate view. Addresses #443 